### PR TITLE
PHP 7.4: Fix Trying to access array offset on value of type bool warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4snapshot
 # faster builds on new travis setup not using sudo
 sudo: false
 

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -865,11 +865,13 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             if ($values === true) {
                 $params[$fieldName] = $box->hasAttribute('value') ? $box->getAttribute('value') : 'on';
                 $chFoundByName[$fieldName] = $pos + 1;
-            } elseif ($values[$pos] === true) {
-                $params[$fieldName][$pos] = $box->hasAttribute('value') ? $box->getAttribute('value') : 'on';
-                $chFoundByName[$fieldName] = $pos + 1;
             } elseif (is_array($values)) {
-                array_splice($params[$fieldName], $pos, 1);
+                if ($values[$pos] === true) {
+                    $params[$fieldName][$pos] = $box->hasAttribute('value') ? $box->getAttribute('value') : 'on';
+                    $chFoundByName[$fieldName] = $pos + 1;
+                } else {
+                    array_splice($params[$fieldName], $pos, 1);
+                }
             } else {
                 unset($params[$fieldName]);
             }


### PR DESCRIPTION
This warning is emited when InnerBrowser attempts to set value of checkbox field to a string.