### PR TITLE
PHPUnit 9 compatibility

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -753,7 +753,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         }
         return [
             'Contains',
-            $value,
+            (string)$value,
             $testValues,
             sprintf(
                 'Failed asserting that `%s` is in %s\'s value: %s',

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -11,7 +11,7 @@
 abstract class TestsForWeb extends \Codeception\Test\Unit
 {
     /**
-     * @var \Codeception\Module\PhpBrowser
+     * @var \Codeception\Module\UniversalFramework
      */
     protected $module;
 
@@ -1416,7 +1416,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->checkOption('#bmessage-topicslinks input[value="4"]');
         $this->module->click('Submit');
         $data = data::get('form');
-        $this->assertContains(4, $data['BMessage']['topicsLinks']);
+        $this->assertContains('4', $data['BMessage']['topicsLinks']);
     }
 
     /**


### PR DESCRIPTION
* Fixed 1 broken test
* proceedSeeInField casts value to string before comparison 