### PR TITLE
Add file output prefix

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -93,7 +93,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $extension = isset($extensions[$responseMimeType]) ? $extensions[$responseMimeType] : 'html';
         
         $filename = mb_strcut($filename, 0, 244, 'utf-8') . '.fail.' . $extension;
-        $this->_savePageSource($report = codecept_output_dir() . $filename);
+        $this->_savePageSource($report = codecept_output_dir($this->_getConfig('output_dir_suffix')) . $filename);
         $test->getMetadata()->addReport('html', $report);
         $test->getMetadata()->addReport('response', $report);
     }


### PR DESCRIPTION
Having issues with PHPBrowser overwriting test output from WebDriver, a configurable prefix here aims to help prevent that, not sure if there's a better way though.