### PR TITLE
Maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
 language: php
 stages:
   - test
-  - 
 php:
   - 5.6
   - 7.0
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
-# faster builds on new travis setup not using sudo
-sudo: false
+  - 7.4
 
 install:
   - '[[ -z "$CI_USER_TOKEN" ]] || composer config github-oauth.github.com ${CI_USER_TOKEN};'
@@ -18,7 +15,7 @@ install:
   - COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-dist --no-interaction
   - phpenv config-rm xdebug.ini
   - if [[ "$TRAVIS_PHP_VERSION" == "7.3" ]]; then pecl install -f pcov; fi
-  
+
 script:
   - php ./vendor/bin/codecept run
   - if [[ "$TRAVIS_PHP_VERSION" == "7.3" ]]; then php ./vendor/bin/codecept run --coverage-xml; fi

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,10 @@
         "php": ">=5.6.0 <8.0",
         "codeception/codeception": "*@dev",
         "symfony/browser-kit": ">=2.7 <6.0",
-        "symfony/dom-crawler": ">=2.7 <6.0"
+        "symfony/dom-crawler": ">=2.7 <6.0",
+        "ext-mbstring": "*",
+        "ext-dom": "*",
+        "ext-json": "*"
     },
     "require-dev": {
         "codeception/util-universalframework": "dev-master"

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -25,6 +25,7 @@ use Symfony\Component\BrowserKit\Exception\BadMethodCallException;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Field\ChoiceFormField;
 use Symfony\Component\DomCrawler\Field\FileFormField;
+use Symfony\Component\DomCrawler\Field\FormField;
 use Symfony\Component\DomCrawler\Field\InputFormField;
 use Symfony\Component\DomCrawler\Field\TextareaFormField;
 use Symfony\Component\DomCrawler\Form;
@@ -57,7 +58,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
 
     protected $defaultCookieParameters = ['expires' => null, 'path' => '/', 'domain' => '', 'secure' => false];
 
-    protected $internalDomains = null;
+    protected $internalDomains;
 
     private $baseUrl;
 
@@ -73,7 +74,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             return;
         }
         $filename = preg_replace('~\W~', '.', Descriptor::getTestSignatureUnique($test));
-        
+
         $extensions = [
             'application/json' => 'json',
             'text/xml' => 'xml',
@@ -86,12 +87,12 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         } catch (BadMethodCallException $e) {
             $internalResponse = false;
         }
-        
+
         $responseContentType = $internalResponse ? $internalResponse->getHeader('content-type') : '';
         list($responseMimeType) = explode(';', $responseContentType);
-        
+
         $extension = isset($extensions[$responseMimeType]) ? $extensions[$responseMimeType] : 'html';
-        
+
         $filename = mb_strcut($filename, 0, 244, 'utf-8') . '.fail.' . $extension;
         $this->_savePageSource($report = codecept_output_dir() . $filename);
         $test->getMetadata()->addReport('html', $report);
@@ -444,7 +445,9 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             if ($tag === 'a') {
                 $this->openHrefFromDomNode($node);
                 return true;
-            } elseif (in_array($tag, ['input', 'button']) && in_array($type, ['submit', 'image'])) {
+            }
+
+            if (in_array($tag, ['input', 'button']) && in_array($type, ['submit', 'image'])) {
                 return $this->clickButton($node);
             }
         }
@@ -490,15 +493,15 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
                 $formParams
             );
             return true;
-        } else {
-            // Check if the button is inside an anchor.
-            $currentNode = $node;
-            while ($currentNode->parentNode !== null) {
-                $currentNode = $currentNode->parentNode;
-                if ($currentNode->nodeName === 'a') {
-                    $this->openHrefFromDomNode($currentNode);
-                    return true;
-                }
+        }
+
+        // Check if the button is inside an anchor.
+        $currentNode = $node;
+        while ($currentNode->parentNode !== null) {
+            $currentNode = $currentNode->parentNode;
+            if ($currentNode->nodeName === 'a') {
+                $this->openHrefFromDomNode($currentNode);
+                return true;
             }
         }
         throw new TestRuntimeException('Button is not inside a link or a form');
@@ -523,7 +526,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         if (count($baseHref) > 0) {
             $baseUrl = $baseHref->getNode(0)->getAttribute('href');
         }
-        if ($baseUrl == '') {
+        if ($baseUrl === '') {
             $baseUrl = $this->_getCurrentUri();
         }
         return $this->getAbsoluteUrlFor($baseUrl);
@@ -579,10 +582,8 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     public function dontSeeLink($text, $url = '')
     {
         $crawler = $this->getCrawler()->selectLink($text);
-        if (!$url) {
-            if ($crawler->count() > 0) {
-                $this->fail("Link containing text '$text' was found in page " . $this->_getCurrentUri());
-            }
+        if (!$url && $crawler->count() > 0) {
+            $this->fail("Link containing text '$text' was found in page " . $this->_getCurrentUri());
         }
         $crawler = $crawler->filterXPath(
             sprintf('.//a[substring(@href, string-length(@href) - string-length(%1$s) + 1)=%1$s]',
@@ -694,9 +695,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             $this->pushFormField($fields, $form, $name, $values);
         }
 
-        foreach ($fields as $element) {
-            list($field, $values) = $element;
-
+        foreach ($fields as list($field, $values)) {
             if (!is_array($values)) {
                 $values = [$values];
             }
@@ -805,7 +804,8 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
      */
     protected function getInputValue($input)
     {
-        if ($input->attr('type') == 'checkbox' or $input->attr('type') == 'radio') {
+        $inputType = $input->attr('type');
+        if ($inputType === 'checkbox' || $inputType === 'radio') {
             $values = [];
 
             foreach ($input->filter(':checked') as $checkbox) {
@@ -854,10 +854,12 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         foreach ($checkboxes as $box) {
             $fieldName = $this->getSubmissionFormFieldName($box->getAttribute('name'));
             $pos = (!isset($chFoundByName[$fieldName])) ? 0 : $chFoundByName[$fieldName];
-            $skip = (!isset($params[$fieldName]))
+            $skip = !isset($params[$fieldName])
                 || (!is_array($params[$fieldName]) && !is_bool($params[$fieldName]))
-                || (is_array($params[$fieldName]) && $pos >= count($params[$fieldName])
-                || (is_array($params[$fieldName]) && !is_bool($params[$fieldName][$pos])));
+                || (is_array($params[$fieldName]) &&
+                    ($pos >= count($params[$fieldName]) || !is_bool($params[$fieldName][$pos]))
+                );
+
             if ($skip) {
                 continue;
             }
@@ -914,7 +916,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         if (!$url) {
             $url = $this->getFormUrl($frmCrawl);
         }
-        
+
         if (strcasecmp($form->getMethod(), 'GET') === 0) {
             $url = Uri::mergeUrls($url, '?' . http_build_query($requestParams));
         }
@@ -957,7 +959,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     protected function getAbsoluteUrlFor($uri)
     {
         $currentUrl = $this->getRunningClient()->getHistory()->current()->getUri();
-        if (empty($uri) || $uri[0] === '#') {
+        if (empty($uri) || strpos($uri, '#') === 0) {
             return $currentUrl;
         }
         return Uri::mergeUrls($currentUrl, $uri);
@@ -1052,7 +1054,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $values = [];
         $fields = $form->all();
         foreach ($fields as $field) {
-            if ($field->isDisabled() || !$field->hasValue() || $field instanceof FileFormField) {
+            if ($field instanceof FileFormField || $field->isDisabled() || !$field->hasValue()) {
                 continue;
             }
             $fieldName = $this->getSubmissionFormFieldName($field->getName());
@@ -1074,13 +1076,13 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $form = $this->getFormFor($input);
         $name = $input->attr('name');
 
-        $dynamicField = $input->getNode(0)->tagName == 'textarea'
+        $dynamicField = $input->getNode(0)->tagName === 'textarea'
             ? new TextareaFormField($input->getNode(0))
             : new InputFormField($input->getNode(0));
         $formField = $this->matchFormField($name, $form, $dynamicField);
         $formField->setValue($value);
         $input->getNode(0)->setAttribute('value', htmlspecialchars($value));
-        if ($input->getNode(0)->tagName == 'textarea') {
+        if ($input->getNode(0)->tagName === 'textarea') {
             $input->getNode(0)->nodeValue = htmlspecialchars($value);
         }
     }
@@ -1327,7 +1329,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     public function makeHtmlSnapshot($name = null)
     {
         if (empty($name)) {
-            $name = uniqid(date("Y-m-d_H-i-s_"));
+            $name = uniqid(date("Y-m-d_H-i-s_"), true);
         }
         $debugDir = codecept_output_dir() . 'debug';
         if (!is_dir($debugDir)) {
@@ -1410,8 +1412,8 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     {
         foreach ($attributes as $attr => $val) {
             $nodes = $nodes->reduce(
-                function (Crawler $node) use ($attr, $val) {
-                    return $node->attr($attr) == $val;
+                static function (Crawler $node) use ($attr, $val) {
+                    return $node->attr($attr) === $val;
                 }
             );
         }
@@ -1610,7 +1612,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $selected = $this->matchSelectedOption($selector);
         $this->assertDomContains($selected, 'selected option');
         //If element is radio then we need to check value
-        $value = $selected->getNode(0)->tagName == 'option'
+        $value = $selected->getNode(0)->tagName === 'option'
             ? $selected->text()
             : $selected->getNode(0)->getAttribute('value');
         $this->assertEquals($optionText, $value);
@@ -1624,7 +1626,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             return;
         }
         //If element is radio then we need to check value
-        $value = $selected->getNode(0)->tagName == 'option'
+        $value = $selected->getNode(0)->tagName === 'option'
             ? $selected->text()
             : $selected->getNode(0)->getAttribute('value');
         $this->assertNotEquals($optionText, $value);
@@ -1634,7 +1636,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     {
         $nodes = $this->getFieldsByLabelOrCss($select);
         $selectedOptions = $nodes->filter('option[selected],input:checked');
-        if ($selectedOptions->count() == 0) {
+        if ($selectedOptions->count() === 0) {
             $selectedOptions = $nodes->filter('option,input')->first();
         }
         return $selectedOptions;
@@ -1821,7 +1823,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
      */
     protected function matchFormField($name, $form, $dynamicField)
     {
-        if (substr($name, -2) != '[]') {
+        if (substr($name, -2) !== '[]') {
             return $form[$name];
         }
         $name = substr($name, 0, -2);
@@ -1884,6 +1886,8 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
 
     /**
      * @param $result
+     * @param $maxRedirects
+     * @param $redirectCount
      * @return mixed
      */
     protected function redirectIfNecessary($result, $maxRedirects, $redirectCount)
@@ -1891,7 +1895,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $locationHeader = $this->client->getInternalResponse()->getHeader('Location');
         $statusCode = $this->getResponseStatusCode();
         if ($locationHeader && $statusCode >= 300 && $statusCode < 400) {
-            if ($redirectCount == $maxRedirects) {
+            if ($redirectCount === $maxRedirects) {
                 throw new \LogicException(sprintf(
                     'The maximum number (%d) of redirections was reached.',
                     $maxRedirects
@@ -2042,6 +2046,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
      * ```php
      * $I->setServerParameters([]);
      * ```
+     * @param array $params
      */
     public function setServerParameters(array $params)
     {
@@ -2054,6 +2059,8 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
      * ```php
      * $I->haveServerParameter('name', 'value');
      * ```
+     * @param $name
+     * @param $value
      */
     public function haveServerParameter($name, $value)
     {

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -624,12 +624,12 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
 
     public function seeCurrentUrlMatches($uri)
     {
-        \PHPUnit\Framework\Assert::assertRegExp($uri, $this->_getCurrentUri());
+        $this->assertRegExp($uri, $this->_getCurrentUri());
     }
 
     public function dontSeeCurrentUrlMatches($uri)
     {
-        \PHPUnit\Framework\Assert::assertNotRegExp($uri, $this->_getCurrentUri());
+        $this->assertNotRegExp($uri, $this->_getCurrentUri());
     }
 
     public function grabFromCurrentUrl($uri = null)


### PR DESCRIPTION
* Updated (dont)seeCurrentUrlMatches methods to use wrapper method instead of deprecated assert(Not)RegExp method (it was causing Warning).
* Fixed various code smells reported by PhpStorm
* Updated TravisCI configuration to run tests on PHP 7.4