### PR TITLE
Refactor InnerBrowser class

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -7,10 +7,7 @@ use Codeception\Exception\ExternalUrlException;
 use Codeception\Exception\MalformedLocatorException;
 use Codeception\Exception\ModuleException;
 use Codeception\Exception\TestRuntimeException;
-use Codeception\Lib\Interfaces\ConflictsWithModule;
-use Codeception\Lib\Interfaces\ElementLocator;
-use Codeception\Lib\Interfaces\PageSourceSaver;
-use Codeception\Lib\Interfaces\Web;
+use Codeception\Lib\Model\BrowserInterface;
 use Codeception\Lib\Model\ConflictsWithModuleTrait;
 use Codeception\Lib\Model\ElementLocatorTrait;
 use Codeception\Lib\Model\PageSourceSaverTrait;
@@ -46,7 +43,7 @@ if (!class_exists('Symfony\Component\BrowserKit\AbstractBrowser') && class_exist
     class_alias('Symfony\Component\BrowserKit\Client', 'Symfony\Component\BrowserKit\AbstractBrowser');
 }
 
-class InnerBrowser extends Module implements ConflictsWithModule, ElementLocator, PageSourceSaver, Web
+class InnerBrowser extends Module implements BrowserInterface
 {
     use
         ConflictsWithModuleTrait,

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -10,6 +10,10 @@ use Codeception\Lib\Interfaces\ConflictsWithModule;
 use Codeception\Lib\Interfaces\ElementLocator;
 use Codeception\Lib\Interfaces\PageSourceSaver;
 use Codeception\Lib\Interfaces\Web;
+use Codeception\Lib\Model\ConflictsWithModuleTrait;
+use Codeception\Lib\Model\ElementLocatorTrait;
+use Codeception\Lib\Model\PageSourceSaverTrait;
+use Codeception\Lib\Model\WebTrait;
 use Codeception\Module;
 use Codeception\PHPUnit\Constraint\Crawler as CrawlerConstraint;
 use Codeception\PHPUnit\Constraint\CrawlerNot as CrawlerNotConstraint;
@@ -43,6 +47,13 @@ if (!class_exists('Symfony\Component\BrowserKit\AbstractBrowser') && class_exist
 
 class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocator, ConflictsWithModule
 {
+    use
+        ConflictsWithModuleTrait,
+        ElementLocatorTrait,
+        PageSourceSaverTrait,
+        WebTrait
+    ;
+
     private $baseUrl;
 
     /**
@@ -1168,16 +1179,6 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $this->headers = [];
     }
 
-    public function _conflicts()
-    {
-        return 'Codeception\Lib\Interfaces\Web';
-    }
-
-    public function _findElements($locator)
-    {
-        return $this->match($locator);
-    }
-
     /**
      * Send custom request to a backend using method, uri, parameters, etc.
      * Use it in Helpers to create special request actions, like accessing API
@@ -1276,11 +1277,6 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $this->forms = [];
     }
 
-    public function _savePageSource($filename)
-    {
-        file_put_contents($filename, $this->_getResponseContent());
-    }
-
     /**
      * Authenticates user for HTTP_AUTH
      *
@@ -1349,108 +1345,6 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         unset($this->headers[$name]);
     }
 
-
-    public function amOnPage($page)
-    {
-        $this->_loadPage('GET', $page);
-    }
-
-    public function click($link, $context = null)
-    {
-        if ($context) {
-            $this->crawler = $this->match($context);
-        }
-
-        if (is_array($link)) {
-            $this->clickByLocator($link);
-            return;
-        }
-
-        $anchor = $this->strictMatch(['link' => $link]);
-        if (!count($anchor)) {
-            $anchor = $this->getCrawler()->selectLink($link);
-        }
-        if (count($anchor)) {
-            $this->openHrefFromDomNode($anchor->getNode(0));
-            return;
-        }
-
-        $buttonText = str_replace('"', "'", $link);
-        $button = $this->crawler->selectButton($buttonText);
-
-        if (count($button) && $this->clickButton($button->getNode(0))) {
-            return;
-        }
-
-        try {
-            $this->clickByLocator($link);
-        } catch (MalformedLocatorException $e) {
-            throw new ElementNotFound("name=$link", "'$link' is invalid CSS and XPath selector and Link or Button");
-        }
-    }
-
-    public function see($text, $selector = null)
-    {
-        if (!$selector) {
-            $this->assertPageContains($text);
-            return;
-        }
-
-        $nodes = $this->match($selector);
-        $this->assertDomContains($nodes, $this->stringifySelector($selector), $text);
-    }
-
-    public function dontSee($text, $selector = null)
-    {
-        if (!$selector) {
-            $this->assertPageNotContains($text);
-            return;
-        }
-
-        $nodes = $this->match($selector);
-        $this->assertDomNotContains($nodes, $this->stringifySelector($selector), $text);
-    }
-
-    public function seeInSource($raw)
-    {
-        $this->assertPageSourceContains($raw);
-    }
-
-    public function dontSeeInSource($raw)
-    {
-        $this->assertPageSourceNotContains($raw);
-    }
-
-    public function seeLink($text, $url = null)
-    {
-        $crawler = $this->getCrawler()->selectLink($text);
-        if ($crawler->count() === 0) {
-            $this->fail("No links containing text '$text' were found in page " . $this->_getCurrentUri());
-        }
-        if ($url) {
-            $crawler = $crawler->filterXPath(sprintf('.//a[substring(@href, string-length(@href) - string-length(%1$s) + 1)=%1$s]', Crawler::xpathLiteral($url)));
-            if ($crawler->count() === 0) {
-                $this->fail("No links containing text '$text' and URL '$url' were found in page " . $this->_getCurrentUri());
-            }
-        }
-        $this->assertTrue(true);
-    }
-
-    public function dontSeeLink($text, $url = '')
-    {
-        $crawler = $this->getCrawler()->selectLink($text);
-        if (!$url && $crawler->count() > 0) {
-            $this->fail("Link containing text '$text' was found in page " . $this->_getCurrentUri());
-        }
-        $crawler = $crawler->filterXPath(
-            sprintf('.//a[substring(@href, string-length(@href) - string-length(%1$s) + 1)=%1$s]',
-            Crawler::xpathLiteral($url))
-        );
-        if ($crawler->count() > 0) {
-            $this->fail("Link containing text '$text' and URL '$url' was found in page " . $this->_getCurrentUri());
-        }
-    }
-
     /**
      * @return string
      * @throws ModuleException
@@ -1458,182 +1352,6 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     public function _getCurrentUri()
     {
         return Uri::retrieveUri($this->getRunningClient()->getHistory()->current()->getUri());
-    }
-
-    public function seeInCurrentUrl($uri)
-    {
-        $this->assertStringContainsString($uri, $this->_getCurrentUri());
-    }
-
-    public function dontSeeInCurrentUrl($uri)
-    {
-        $this->assertStringNotContainsString($uri, $this->_getCurrentUri());
-    }
-
-    public function seeCurrentUrlEquals($uri)
-    {
-        $this->assertEquals(rtrim($uri, '/'), rtrim($this->_getCurrentUri(), '/'));
-    }
-
-    public function dontSeeCurrentUrlEquals($uri)
-    {
-        $this->assertNotEquals(rtrim($uri, '/'), rtrim($this->_getCurrentUri(), '/'));
-    }
-
-    public function seeCurrentUrlMatches($uri)
-    {
-        $this->assertRegExp($uri, $this->_getCurrentUri());
-    }
-
-    public function dontSeeCurrentUrlMatches($uri)
-    {
-        $this->assertNotRegExp($uri, $this->_getCurrentUri());
-    }
-
-    public function grabFromCurrentUrl($uri = null)
-    {
-        if (!$uri) {
-            return $this->_getCurrentUri();
-        }
-        $matches = [];
-        $res     = preg_match($uri, $this->_getCurrentUri(), $matches);
-        if (!$res) {
-            $this->fail("Couldn't match $uri in " . $this->_getCurrentUri());
-        }
-        if (!isset($matches[1])) {
-            $this->fail("Nothing to grab. A regex parameter required. Ex: '/user/(\\d+)'");
-        }
-        return $matches[1];
-    }
-
-    public function seeCheckboxIsChecked($checkbox)
-    {
-        $checkboxes = $this->getFieldsByLabelOrCss($checkbox);
-        $this->assertDomContains($checkboxes->filter('input[checked=checked]'), 'checkbox');
-    }
-
-    public function dontSeeCheckboxIsChecked($checkbox)
-    {
-        $checkboxes = $this->getFieldsByLabelOrCss($checkbox);
-        $this->assertEquals(0, $checkboxes->filter('input[checked=checked]')->count());
-    }
-
-    public function seeInField($field, $value)
-    {
-        $nodes = $this->getFieldsByLabelOrCss($field);
-        $this->assert($this->proceedSeeInField($nodes, $value));
-    }
-
-    public function dontSeeInField($field, $value)
-    {
-        $nodes = $this->getFieldsByLabelOrCss($field);
-        $this->assertNot($this->proceedSeeInField($nodes, $value));
-    }
-
-    public function seeInFormFields($formSelector, array $params)
-    {
-        $this->proceedSeeInFormFields($formSelector, $params, false);
-    }
-
-    public function dontSeeInFormFields($formSelector, array $params)
-    {
-        $this->proceedSeeInFormFields($formSelector, $params, true);
-    }
-
-    public function submitForm($selector, array $params, $button = null)
-    {
-        $form = $this->match($selector)->first();
-        if (!count($form)) {
-            throw new ElementNotFound($this->stringifySelector($selector), 'Form');
-        }
-        $this->proceedSubmitForm($form, $params, $button);
-    }
-
-    public function fillField($field, $value)
-    {
-        $input = $this->getFieldByLabelOrCss($field);
-        $form = $this->getFormFor($input);
-        $name = $input->attr('name');
-
-        $dynamicField = $input->getNode(0)->tagName === 'textarea'
-            ? new TextareaFormField($input->getNode(0))
-            : new InputFormField($input->getNode(0));
-        $formField = $this->matchFormField($name, $form, $dynamicField);
-        $formField->setValue($value);
-        $input->getNode(0)->setAttribute('value', htmlspecialchars($value));
-        if ($input->getNode(0)->tagName === 'textarea') {
-            $input->getNode(0)->nodeValue = htmlspecialchars($value);
-        }
-    }
-
-    public function selectOption($select, $option)
-    {
-        $field = $this->getFieldByLabelOrCss($select);
-        $form = $this->getFormFor($field);
-        $fieldName = $this->getSubmissionFormFieldName($field->attr('name'));
-
-        if (is_array($option)) {
-            if (!isset($option[0])) { // strict option locator
-                $form[$fieldName]->select($this->matchOption($field, $option));
-                codecept_debug($option);
-                return;
-            }
-            $options = [];
-            foreach ($option as $opt) {
-                $options[] = $this->matchOption($field, $opt);
-            }
-            $form[$fieldName]->select($options);
-            return;
-        }
-
-        $dynamicField = new ChoiceFormField($field->getNode(0));
-        $formField = $this->matchFormField($fieldName, $form, $dynamicField);
-        $selValue = $this->matchOption($field, $option);
-
-        if (is_array($formField)) {
-            foreach ($formField as $field) {
-                $values = $field->availableOptionValues();
-                foreach ($values as $val) {
-                    if ($val === $option) {
-                        $field->select($selValue);
-                        return;
-                    }
-                }
-            }
-            return;
-        }
-
-        $formField->select($this->matchOption($field, $option));
-    }
-
-    public function checkOption($option)
-    {
-        $this->proceedCheckOption($option)->tick();
-    }
-
-    public function uncheckOption($option)
-    {
-        $this->proceedCheckOption($option)->untick();
-    }
-
-    public function attachFile($field, $filename)
-    {
-        $form = $this->getFormFor($field = $this->getFieldByLabelOrCss($field));
-        $filePath = codecept_data_dir() . $filename;
-        if (!file_exists($filePath)) {
-            throw new InvalidArgumentException("File does not exist: $filePath");
-        }
-        if (!is_readable($filePath)) {
-            throw new InvalidArgumentException("File is not readable: $filePath");
-        }
-
-        $name = $field->attr('name');
-        $formField = $this->matchFormField($name, $form, new FileFormField($field->getNode(0)));
-        if (is_array($formField)) {
-            $this->fail("Field $name is ignored on upload, field $name is treated as array.");
-        }
-
-        $formField->upload($filePath);
     }
 
     /**
@@ -1694,228 +1412,9 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $this->clientRequest($method, $uri, $params, [], ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'], null, false);
     }
 
-    public function makeHtmlSnapshot($name = null)
-    {
-        if (empty($name)) {
-            $name = uniqid(date("Y-m-d_H-i-s_"), true);
-        }
-        $debugDir = codecept_output_dir() . 'debug';
-        if (!is_dir($debugDir)) {
-            mkdir($debugDir, 0777);
-        }
-        $fileName = $debugDir . DIRECTORY_SEPARATOR . $name . '.html';
-
-        $this->_savePageSource($fileName);
-        $this->debugSection('Snapshot Saved', "file://$fileName");
-    }
-
     public function _getResponseStatusCode()
     {
         return $this->getResponseStatusCode();
-    }
-
-    public function grabTextFrom($cssOrXPathOrRegex)
-    {
-        if (@preg_match($cssOrXPathOrRegex, $this->client->getInternalResponse()->getContent(), $matches)) {
-            return $matches[1];
-        }
-        $nodes = $this->match($cssOrXPathOrRegex);
-        if ($nodes->count()) {
-            return $nodes->first()->text();
-        }
-        throw new ElementNotFound($cssOrXPathOrRegex, 'Element that matches CSS or XPath or Regex');
-    }
-
-    public function grabAttributeFrom($cssOrXpath, $attribute)
-    {
-        $nodes = $this->match($cssOrXpath);
-        if (!$nodes->count()) {
-            throw new ElementNotFound($cssOrXpath, 'Element that matches CSS or XPath');
-        }
-        return $nodes->first()->attr($attribute);
-    }
-
-    public function grabMultiple($cssOrXpath, $attribute = null)
-    {
-        $result = [];
-        $nodes = $this->match($cssOrXpath);
-
-        foreach ($nodes as $node) {
-            if ($attribute !== null) {
-                $result[] = $node->getAttribute($attribute);
-            } else {
-                $result[] = $node->textContent;
-            }
-        }
-        return $result;
-    }
-
-    /**
-     * @param $field
-     *
-     * @return array|mixed|null|string
-     */
-    public function grabValueFrom($field)
-    {
-        $nodes = $this->match($field);
-        if (!$nodes->count()) {
-            throw new ElementNotFound($field, 'Field');
-        }
-
-        if ($nodes->filter('textarea')->count()) {
-            return (new TextareaFormField($nodes->filter('textarea')->getNode(0)))->getValue();
-        }
-
-        $input = $nodes->filter('input');
-        if ($input->count()) {
-            return $this->getInputValue($input);
-        }
-
-        if ($nodes->filter('select')->count()) {
-            $field = new ChoiceFormField($nodes->filter('select')->getNode(0));
-            $options = $nodes->filter('option[selected]');
-            $values = [];
-
-            foreach ($options as $option) {
-                $values[] = $option->getAttribute('value');
-            }
-
-            if (!$field->isMultiple()) {
-                return reset($values);
-            }
-
-            return $values;
-        }
-
-        $this->fail("Element $nodes is not a form field or does not contain a form field");
-    }
-
-    public function setCookie($name, $val, array $params = [])
-    {
-        $cookies = $this->client->getCookieJar();
-        $params = array_merge($this->defaultCookieParameters, $params);
-
-        $expires      = isset($params['expiry']) ? $params['expiry'] : null; // WebDriver compatibility
-        $expires      = isset($params['expires']) && !$expires ? $params['expires'] : null;
-        $path         = isset($params['path'])    ? $params['path'] : null;
-        $domain       = isset($params['domain'])  ? $params['domain'] : '';
-        $secure       = isset($params['secure'])  ? $params['secure'] : false;
-        $httpOnly     = isset($params['httpOnly'])  ? $params['httpOnly'] : true;
-        $encodedValue = isset($params['encodedValue'])  ? $params['encodedValue'] : false;
-
-
-
-        $cookies->set(new Cookie($name, $val, $expires, $path, $domain, $secure, $httpOnly, $encodedValue));
-        $this->debugCookieJar();
-    }
-
-    public function grabCookie($cookie, array $params = [])
-    {
-        $params = array_merge($this->defaultCookieParameters, $params);
-        $this->debugCookieJar();
-        $cookies = $this->getRunningClient()->getCookieJar()->get($cookie, $params['path'], $params['domain']);
-        if (!$cookies) {
-            return null;
-        }
-        return $cookies->getValue();
-    }
-
-    /**
-     * Grabs current page source code.
-     *
-     * @throws ModuleException if no page was opened.
-     *
-     * @return string Current page source code.
-     */
-    public function grabPageSource()
-    {
-        return $this->_getResponseContent();
-    }
-
-    public function seeCookie($cookie, array $params = [])
-    {
-        $params = array_merge($this->defaultCookieParameters, $params);
-        $this->debugCookieJar();
-        $this->assertNotNull($this->client->getCookieJar()->get($cookie, $params['path'], $params['domain']));
-    }
-
-    public function dontSeeCookie($cookie, array $params = [])
-    {
-        $params = array_merge($this->defaultCookieParameters, $params);
-        $this->debugCookieJar();
-        $this->assertNull($this->client->getCookieJar()->get($cookie, $params['path'], $params['domain']));
-    }
-
-    public function resetCookie($name, array $params = [])
-    {
-        $params = array_merge($this->defaultCookieParameters, $params);
-        $this->client->getCookieJar()->expire($name, $params['path'], $params['domain']);
-        $this->debugCookieJar();
-    }
-
-    public function seeElement($selector, $attributes = [])
-    {
-        $nodes = $this->match($selector);
-        $selector = $this->stringifySelector($selector);
-        if (!empty($attributes)) {
-            $nodes = $this->filterByAttributes($nodes, $attributes);
-            $selector .= "' with attribute(s) '" . trim(json_encode($attributes), '{}');
-        }
-        $this->assertDomContains($nodes, $selector);
-    }
-
-    public function dontSeeElement($selector, $attributes = [])
-    {
-        $nodes = $this->match($selector);
-        $selector = $this->stringifySelector($selector);
-        if (!empty($attributes)) {
-            $nodes = $this->filterByAttributes($nodes, $attributes);
-            $selector .= "' with attribute(s) '" . trim(json_encode($attributes), '{}');
-        }
-        $this->assertDomNotContains($nodes, $selector);
-    }
-
-    public function seeNumberOfElements($selector, $expected)
-    {
-        $counted = count($this->match($selector));
-        if (is_array($expected)) {
-            list($floor, $ceil) = $expected;
-            $this->assertTrue(
-                $floor <= $counted && $ceil >= $counted,
-                'Number of elements counted differs from expected range'
-            );
-        } else {
-            $this->assertEquals(
-                $expected,
-                $counted,
-                'Number of elements counted differs from expected number'
-            );
-        }
-    }
-
-    public function seeOptionIsSelected($selector, $optionText)
-    {
-        $selected = $this->matchSelectedOption($selector);
-        $this->assertDomContains($selected, 'selected option');
-        //If element is radio then we need to check value
-        $value = $selected->getNode(0)->tagName === 'option'
-            ? $selected->text()
-            : $selected->getNode(0)->getAttribute('value');
-        $this->assertEquals($optionText, $value);
-    }
-
-    public function dontSeeOptionIsSelected($selector, $optionText)
-    {
-        $selected = $this->matchSelectedOption($selector);
-        if (!$selected->count()) {
-            $this->assertEquals(0, $selected->count());
-            return;
-        }
-        //If element is radio then we need to check value
-        $value = $selected->getNode(0)->tagName === 'option'
-            ? $selected->text()
-            : $selected->getNode(0)->getAttribute('value');
-        $this->assertNotEquals($optionText, $value);
     }
 
     /**
@@ -2018,25 +1517,6 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     public function seeResponseCodeIsServerError()
     {
         $this->seeResponseCodeIsBetween(500, 599);
-    }
-
-    public function seeInTitle($title)
-    {
-        $nodes = $this->getCrawler()->filter('title');
-        if (!$nodes->count()) {
-            throw new ElementNotFound("<title>", "Tag");
-        }
-        $this->assertStringContainsString($title, $nodes->first()->text(), "page title contains $title");
-    }
-
-    public function dontSeeInTitle($title)
-    {
-        $nodes = $this->getCrawler()->filter('title');
-        if (!$nodes->count()) {
-            $this->assertTrue(true);
-            return;
-        }
-        $this->assertStringNotContainsString($title, $nodes->first()->text(), "page title contains $title");
     }
 
     /**

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Codeception\Lib;
 
 use Codeception\Exception\ElementNotFound;
@@ -45,7 +46,7 @@ if (!class_exists('Symfony\Component\BrowserKit\AbstractBrowser') && class_exist
     class_alias('Symfony\Component\BrowserKit\Client', 'Symfony\Component\BrowserKit\AbstractBrowser');
 }
 
-class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocator, ConflictsWithModule
+class InnerBrowser extends Module implements ConflictsWithModule, ElementLocator, PageSourceSaver, Web
 {
     use
         ConflictsWithModuleTrait,
@@ -87,7 +88,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
      * Clicks the link or submits the form when the button is clicked
      * @param DOMNode $node
      * @return boolean clicked something
-     * @throws ModuleException
+     * @throws ModuleException|ExternalUrlException
      */
     private function clickButton(DOMNode $node)
     {
@@ -173,6 +174,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
      *
      * @param Crawler $form the form
      * @return Form
+     * @throws ModuleException
      */
     private function getFormFromCrawler(Crawler $form)
     {
@@ -245,6 +247,17 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         return $selector;
     }
 
+    /**
+     * @param $method
+     * @param $uri
+     * @param array $parameters
+     * @param array $files
+     * @param array $server
+     * @param null $content
+     * @param bool $changeHistory
+     * @return mixed|Crawler|null
+     * @throws ExternalUrlException|ModuleException
+     */
     protected function clientRequest(
         $method,
         $uri,
@@ -325,7 +338,6 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     /**
      * @param $needle
      * @param string $message
-     * @throws ModuleException
      */
     protected function assertPageContains($needle, $message = '')
     {
@@ -340,7 +352,6 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     /**
      * @param $needle
      * @param string $message
-     * @throws ModuleException
      */
     protected function assertPageNotContains($needle, $message = '')
     {
@@ -375,7 +386,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     /**
      * @param $link
      * @return bool
-     * @throws ModuleException
+     * @throws ModuleException|ExternalUrlException
      */
     protected function clickByLocator($link)
     {
@@ -535,6 +546,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
      *
      * @param Crawler $node
      * @return Form
+     * @throws ModuleException
      */
     protected function getFormFor(Crawler $node)
     {
@@ -646,7 +658,6 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
 
     /**
      * @return string
-     * @throws ModuleException
      */
     protected function getNormalizedResponseContent()
     {

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -20,6 +20,7 @@ use Codeception\Util\HttpCode;
 use Codeception\Util\Locator;
 use Codeception\Util\ReflectionHelper;
 use Codeception\Util\Uri;
+use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\BrowserKit\Exception\BadMethodCallException;
 use Symfony\Component\DomCrawler\Crawler;
@@ -38,29 +39,34 @@ if (!class_exists('Symfony\Component\BrowserKit\AbstractBrowser') && class_exist
 
 class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocator, ConflictsWithModule
 {
+    private $baseUrl;
+
     /**
-     * @var \Symfony\Component\DomCrawler\Crawler
+     * @var Crawler
      */
     protected $crawler;
 
-    /**
-     * @api
-     * @var \Symfony\Component\BrowserKit\AbstractBrowser
-     */
-    public $client;
+    protected $defaultCookieParameters = [
+        'expires' => null,
+        'path' => '/',
+        'domain' => '',
+        'secure' => false
+    ];
 
     /**
-     * @var array|\Symfony\Component\DomCrawler\Form[]
+     * @var array|Form[]
      */
     protected $forms = [];
 
-    public $headers = [];
-
-    protected $defaultCookieParameters = ['expires' => null, 'path' => '/', 'domain' => '', 'secure' => false];
-
     protected $internalDomains;
 
-    private $baseUrl;
+    /**
+     * @api
+     * @var AbstractBrowser
+     */
+    public $client;
+
+    public $headers = [];
 
     public function _failed(TestInterface $test, $fail)
     {

--- a/src/Codeception/Lib/Model/BrowserInterface.php
+++ b/src/Codeception/Lib/Model/BrowserInterface.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Codeception\Lib\Model;
+
+use Codeception\Lib\Interfaces\ConflictsWithModule;
+use Codeception\Lib\Interfaces\ElementLocator;
+use Codeception\Lib\Interfaces\PageSourceSaver;
+use Codeception\Lib\Interfaces\Web;
+use Codeception\TestInterface;
+
+interface BrowserInterface extends ConflictsWithModule, ElementLocator, PageSourceSaver, Web
+{
+    public function _after(TestInterface $test);
+
+    public function _failed(TestInterface $test, $fail);
+
+    public function _getCurrentUri();
+
+    public function _getResponseContent();
+
+    public function _getResponseStatusCode();
+
+    public function _loadPage(
+        $method,
+        $uri,
+        array $parameters = [],
+        array $files = [],
+        array $server = [],
+        $content = null
+    );
+
+    public function _request(
+        $method,
+        $uri,
+        array $parameters = [],
+        array $files = [],
+        array $server = [],
+        $content = null
+    );
+
+    public function amHttpAuthenticated($username, $password);
+
+    public function deleteHeader($name);
+
+    public function dontSeeResponseCodeIs($code);
+
+    public function haveHttpHeader($name, $value);
+
+    public function haveServerParameter($name, $value);
+
+    public function moveBack($numberOfSteps = 1);
+
+    public function seePageNotFound();
+
+    public function seeResponseCodeIs($code);
+
+    public function seeResponseCodeIsBetween($from, $to);
+
+    public function seeResponseCodeIsClientError();
+
+    public function seeResponseCodeIsRedirection();
+
+    public function seeResponseCodeIsServerError();
+
+    public function seeResponseCodeIsSuccessful();
+
+    public function sendAjaxGetRequest($uri, $params = []);
+
+    public function sendAjaxPostRequest($uri, $params = []);
+
+    public function sendAjaxRequest($method, $uri, $params = []);
+
+    public function setServerParameters(array $params);
+
+    public function switchToIframe($name);
+}

--- a/src/Codeception/Lib/Model/ConflictsWithModuleTrait.php
+++ b/src/Codeception/Lib/Model/ConflictsWithModuleTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Codeception\Lib\Model;
+
+use Codeception\Lib\Interfaces\ConflictsWithModule;
+use Codeception\Lib\Interfaces\Web;
+
+/**
+ * @see ConflictsWithModule
+ */
+trait ConflictsWithModuleTrait
+{
+    public function _conflicts()
+    {
+        return Web::class;
+    }
+}

--- a/src/Codeception/Lib/Model/ElementLocatorTrait.php
+++ b/src/Codeception/Lib/Model/ElementLocatorTrait.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Codeception\Lib\Model;
+
+use Codeception\Lib\Interfaces\ElementLocator;
+
+/**
+ * @see ElementLocator
+ */
+trait ElementLocatorTrait
+{
+    public function _findElements($locator)
+    {
+        return $this->match($locator);
+    }
+}

--- a/src/Codeception/Lib/Model/PageSourceSaverTrait.php
+++ b/src/Codeception/Lib/Model/PageSourceSaverTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Codeception\Lib\Model;
+
+use Codeception\Lib\Interfaces\PageSourceSaver;
+
+/**
+ * @see PageSourceSaver
+ */
+trait PageSourceSaverTrait
+{
+    public function _savePageSource($filename)
+    {
+        file_put_contents($filename, $this->_getResponseContent());
+    }
+
+    public function makeHtmlSnapshot($name = null)
+    {
+        if (empty($name)) {
+            $name = uniqid(date("Y-m-d_H-i-s_"), true);
+        }
+        $debugDir = codecept_output_dir() . 'debug';
+        if (!is_dir($debugDir)) {
+            mkdir($debugDir, 0777);
+        }
+        $fileName = $debugDir . DIRECTORY_SEPARATOR . $name . '.html';
+
+        $this->_savePageSource($fileName);
+        $this->debugSection('Snapshot Saved', "file://$fileName");
+    }
+}

--- a/src/Codeception/Lib/Model/WebTrait.php
+++ b/src/Codeception/Lib/Model/WebTrait.php
@@ -1,0 +1,516 @@
+<?php
+
+namespace Codeception\Lib\Model;
+
+use Codeception\Exception\ElementNotFound;
+use Codeception\Exception\MalformedLocatorException;
+use Codeception\Lib\Interfaces\Web;
+use InvalidArgumentException;
+use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\DomCrawler\Field\ChoiceFormField;
+use Symfony\Component\DomCrawler\Field\FileFormField;
+use Symfony\Component\DomCrawler\Field\InputFormField;
+use Symfony\Component\DomCrawler\Field\TextareaFormField;
+
+/**
+ * @see Web
+ */
+trait WebTrait
+{
+    public function amOnPage($page)
+    {
+        $this->_loadPage('GET', $page);
+    }
+
+    public function see($text, $selector = null)
+    {
+        if (!$selector) {
+            $this->assertPageContains($text);
+            return;
+        }
+
+        $nodes = $this->match($selector);
+        $this->assertDomContains($nodes, $this->stringifySelector($selector), $text);
+    }
+
+    public function dontSee($text, $selector = null)
+    {
+        if (!$selector) {
+            $this->assertPageNotContains($text);
+            return;
+        }
+
+        $nodes = $this->match($selector);
+        $this->assertDomNotContains($nodes, $this->stringifySelector($selector), $text);
+    }
+
+    public function seeInSource($raw)
+    {
+        $this->assertPageSourceContains($raw);
+    }
+
+    public function dontSeeInSource($raw)
+    {
+        $this->assertPageSourceNotContains($raw);
+    }
+
+    public function submitForm($selector, array $params, $button = null)
+    {
+        $form = $this->match($selector)->first();
+        if (!count($form)) {
+            throw new ElementNotFound($this->stringifySelector($selector), 'Form');
+        }
+        $this->proceedSubmitForm($form, $params, $button);
+    }
+
+    public function click($link, $context = null)
+    {
+        if ($context) {
+            $this->crawler = $this->match($context);
+        }
+
+        if (is_array($link)) {
+            $this->clickByLocator($link);
+            return;
+        }
+
+        $anchor = $this->strictMatch(['link' => $link]);
+        if (!count($anchor)) {
+            $anchor = $this->getCrawler()->selectLink($link);
+        }
+        if (count($anchor)) {
+            $this->openHrefFromDomNode($anchor->getNode(0));
+            return;
+        }
+
+        $buttonText = str_replace('"', "'", $link);
+        $button = $this->crawler->selectButton($buttonText);
+
+        if (count($button) && $this->clickButton($button->getNode(0))) {
+            return;
+        }
+
+        try {
+            $this->clickByLocator($link);
+        } catch (MalformedLocatorException $e) {
+            throw new ElementNotFound("name=$link", "'$link' is invalid CSS and XPath selector and Link or Button");
+        }
+    }
+
+    public function seeLink($text, $url = null)
+    {
+        $crawler = $this->getCrawler()->selectLink($text);
+        if ($crawler->count() === 0) {
+            $this->fail("No links containing text '$text' were found in page " . $this->_getCurrentUri());
+        }
+        if ($url) {
+            $crawler = $crawler->filterXPath(sprintf('.//a[substring(@href, string-length(@href) - string-length(%1$s) + 1)=%1$s]', Crawler::xpathLiteral($url)));
+            if ($crawler->count() === 0) {
+                $this->fail("No links containing text '$text' and URL '$url' were found in page " . $this->_getCurrentUri());
+            }
+        }
+        $this->assertTrue(true);
+    }
+
+    public function dontSeeLink($text, $url = '')
+    {
+        $crawler = $this->getCrawler()->selectLink($text);
+        if (!$url && $crawler->count() > 0) {
+            $this->fail("Link containing text '$text' was found in page " . $this->_getCurrentUri());
+        }
+        $crawler = $crawler->filterXPath(
+            sprintf('.//a[substring(@href, string-length(@href) - string-length(%1$s) + 1)=%1$s]',
+                Crawler::xpathLiteral($url))
+        );
+        if ($crawler->count() > 0) {
+            $this->fail("Link containing text '$text' and URL '$url' was found in page " . $this->_getCurrentUri());
+        }
+    }
+
+    public function seeInCurrentUrl($uri)
+    {
+        $this->assertStringContainsString($uri, $this->_getCurrentUri());
+    }
+
+    public function seeCurrentUrlEquals($uri)
+    {
+        $this->assertEquals(rtrim($uri, '/'), rtrim($this->_getCurrentUri(), '/'));
+    }
+
+    public function seeCurrentUrlMatches($uri)
+    {
+        $this->assertRegExp($uri, $this->_getCurrentUri());
+    }
+
+    public function dontSeeInCurrentUrl($uri)
+    {
+        $this->assertStringNotContainsString($uri, $this->_getCurrentUri());
+    }
+
+    public function dontSeeCurrentUrlEquals($uri)
+    {
+        $this->assertNotEquals(rtrim($uri, '/'), rtrim($this->_getCurrentUri(), '/'));
+    }
+
+    public function dontSeeCurrentUrlMatches($uri)
+    {
+        $this->assertNotRegExp($uri, $this->_getCurrentUri());
+    }
+
+    public function grabFromCurrentUrl($uri = null)
+    {
+        if (!$uri) {
+            return $this->_getCurrentUri();
+        }
+        $matches = [];
+        $res     = preg_match($uri, $this->_getCurrentUri(), $matches);
+        if (!$res) {
+            $this->fail("Couldn't match $uri in " . $this->_getCurrentUri());
+        }
+        if (!isset($matches[1])) {
+            $this->fail("Nothing to grab. A regex parameter required. Ex: '/user/(\\d+)'");
+        }
+        return $matches[1];
+    }
+
+    public function seeCheckboxIsChecked($checkbox)
+    {
+        $checkboxes = $this->getFieldsByLabelOrCss($checkbox);
+        $this->assertDomContains($checkboxes->filter('input[checked=checked]'), 'checkbox');
+    }
+
+    public function dontSeeCheckboxIsChecked($checkbox)
+    {
+        $checkboxes = $this->getFieldsByLabelOrCss($checkbox);
+        $this->assertEquals(0, $checkboxes->filter('input[checked=checked]')->count());
+    }
+
+    public function seeInField($field, $value)
+    {
+        $nodes = $this->getFieldsByLabelOrCss($field);
+        $this->assert($this->proceedSeeInField($nodes, $value));
+    }
+
+    public function dontSeeInField($field, $value)
+    {
+        $nodes = $this->getFieldsByLabelOrCss($field);
+        $this->assertNot($this->proceedSeeInField($nodes, $value));
+    }
+
+    public function seeInFormFields($formSelector, array $params)
+    {
+        $this->proceedSeeInFormFields($formSelector, $params, false);
+    }
+
+    public function dontSeeInFormFields($formSelector, array $params)
+    {
+        $this->proceedSeeInFormFields($formSelector, $params, true);
+    }
+
+    public function selectOption($select, $option)
+    {
+        $field = $this->getFieldByLabelOrCss($select);
+        $form = $this->getFormFor($field);
+        $fieldName = $this->getSubmissionFormFieldName($field->attr('name'));
+
+        if (is_array($option)) {
+            if (!isset($option[0])) { // strict option locator
+                $form[$fieldName]->select($this->matchOption($field, $option));
+                codecept_debug($option);
+                return;
+            }
+            $options = [];
+            foreach ($option as $opt) {
+                $options[] = $this->matchOption($field, $opt);
+            }
+            $form[$fieldName]->select($options);
+            return;
+        }
+
+        $dynamicField = new ChoiceFormField($field->getNode(0));
+        $formField = $this->matchFormField($fieldName, $form, $dynamicField);
+        $selValue = $this->matchOption($field, $option);
+
+        if (is_array($formField)) {
+            foreach ($formField as $field) {
+                $values = $field->availableOptionValues();
+                foreach ($values as $val) {
+                    if ($val === $option) {
+                        $field->select($selValue);
+                        return;
+                    }
+                }
+            }
+            return;
+        }
+
+        $formField->select($this->matchOption($field, $option));
+    }
+
+    public function checkOption($option)
+    {
+        $this->proceedCheckOption($option)->tick();
+    }
+
+    public function uncheckOption($option)
+    {
+        $this->proceedCheckOption($option)->untick();
+    }
+
+    public function fillField($field, $value)
+    {
+        $input = $this->getFieldByLabelOrCss($field);
+        $form = $this->getFormFor($input);
+        $name = $input->attr('name');
+
+        $dynamicField = $input->getNode(0)->tagName === 'textarea'
+            ? new TextareaFormField($input->getNode(0))
+            : new InputFormField($input->getNode(0));
+        $formField = $this->matchFormField($name, $form, $dynamicField);
+        $formField->setValue($value);
+        $input->getNode(0)->setAttribute('value', htmlspecialchars($value));
+        if ($input->getNode(0)->tagName === 'textarea') {
+            $input->getNode(0)->nodeValue = htmlspecialchars($value);
+        }
+    }
+
+    public function attachFile($field, $filename)
+    {
+        $form = $this->getFormFor($field = $this->getFieldByLabelOrCss($field));
+        $filePath = codecept_data_dir() . $filename;
+        if (!file_exists($filePath)) {
+            throw new InvalidArgumentException("File does not exist: $filePath");
+        }
+        if (!is_readable($filePath)) {
+            throw new InvalidArgumentException("File is not readable: $filePath");
+        }
+
+        $name = $field->attr('name');
+        $formField = $this->matchFormField($name, $form, new FileFormField($field->getNode(0)));
+        if (is_array($formField)) {
+            $this->fail("Field $name is ignored on upload, field $name is treated as array.");
+        }
+
+        $formField->upload($filePath);
+    }
+
+    public function grabTextFrom($cssOrXPathOrRegex)
+    {
+        if (@preg_match($cssOrXPathOrRegex, $this->client->getInternalResponse()->getContent(), $matches)) {
+            return $matches[1];
+        }
+        $nodes = $this->match($cssOrXPathOrRegex);
+        if ($nodes->count()) {
+            return $nodes->first()->text();
+        }
+        throw new ElementNotFound($cssOrXPathOrRegex, 'Element that matches CSS or XPath or Regex');
+    }
+
+    /**
+     * @param $field
+     *
+     * @return array|mixed|null|string
+     */
+    public function grabValueFrom($field)
+    {
+        $nodes = $this->match($field);
+        if (!$nodes->count()) {
+            throw new ElementNotFound($field, 'Field');
+        }
+
+        if ($nodes->filter('textarea')->count()) {
+            return (new TextareaFormField($nodes->filter('textarea')->getNode(0)))->getValue();
+        }
+
+        $input = $nodes->filter('input');
+        if ($input->count()) {
+            return $this->getInputValue($input);
+        }
+
+        if ($nodes->filter('select')->count()) {
+            $field = new ChoiceFormField($nodes->filter('select')->getNode(0));
+            $options = $nodes->filter('option[selected]');
+            $values = [];
+
+            foreach ($options as $option) {
+                $values[] = $option->getAttribute('value');
+            }
+
+            if (!$field->isMultiple()) {
+                return reset($values);
+            }
+
+            return $values;
+        }
+
+        $this->fail("Element $nodes is not a form field or does not contain a form field");
+    }
+
+    public function grabAttributeFrom($cssOrXpath, $attribute)
+    {
+        $nodes = $this->match($cssOrXpath);
+        if (!$nodes->count()) {
+            throw new ElementNotFound($cssOrXpath, 'Element that matches CSS or XPath');
+        }
+        return $nodes->first()->attr($attribute);
+    }
+
+    public function grabMultiple($cssOrXpath, $attribute = null)
+    {
+        $result = [];
+        $nodes = $this->match($cssOrXpath);
+
+        foreach ($nodes as $node) {
+            if ($attribute !== null) {
+                $result[] = $node->getAttribute($attribute);
+            } else {
+                $result[] = $node->textContent;
+            }
+        }
+        return $result;
+    }
+
+    public function seeElement($selector, $attributes = [])
+    {
+        $nodes = $this->match($selector);
+        $selector = $this->stringifySelector($selector);
+        if (!empty($attributes)) {
+            $nodes = $this->filterByAttributes($nodes, $attributes);
+            $selector .= "' with attribute(s) '" . trim(json_encode($attributes), '{}');
+        }
+        $this->assertDomContains($nodes, $selector);
+    }
+
+    public function dontSeeElement($selector, $attributes = [])
+    {
+        $nodes = $this->match($selector);
+        $selector = $this->stringifySelector($selector);
+        if (!empty($attributes)) {
+            $nodes = $this->filterByAttributes($nodes, $attributes);
+            $selector .= "' with attribute(s) '" . trim(json_encode($attributes), '{}');
+        }
+        $this->assertDomNotContains($nodes, $selector);
+    }
+
+    public function seeNumberOfElements($selector, $expected)
+    {
+        $counted = count($this->match($selector));
+        if (is_array($expected)) {
+            list($floor, $ceil) = $expected;
+            $this->assertTrue(
+                $floor <= $counted && $ceil >= $counted,
+                'Number of elements counted differs from expected range'
+            );
+        } else {
+            $this->assertEquals(
+                $expected,
+                $counted,
+                'Number of elements counted differs from expected number'
+            );
+        }
+    }
+
+    public function seeOptionIsSelected($selector, $optionText)
+    {
+        $selected = $this->matchSelectedOption($selector);
+        $this->assertDomContains($selected, 'selected option');
+        //If element is radio then we need to check value
+        $value = $selected->getNode(0)->tagName === 'option'
+            ? $selected->text()
+            : $selected->getNode(0)->getAttribute('value');
+        $this->assertEquals($optionText, $value);
+    }
+
+    public function dontSeeOptionIsSelected($selector, $optionText)
+    {
+        $selected = $this->matchSelectedOption($selector);
+        if (!$selected->count()) {
+            $this->assertEquals(0, $selected->count());
+            return;
+        }
+        //If element is radio then we need to check value
+        $value = $selected->getNode(0)->tagName === 'option'
+            ? $selected->text()
+            : $selected->getNode(0)->getAttribute('value');
+        $this->assertNotEquals($optionText, $value);
+    }
+
+    public function seeInTitle($title)
+    {
+        $nodes = $this->getCrawler()->filter('title');
+        if (!$nodes->count()) {
+            throw new ElementNotFound("<title>", "Tag");
+        }
+        $this->assertStringContainsString($title, $nodes->first()->text(), "page title contains $title");
+    }
+
+    public function dontSeeInTitle($title)
+    {
+        $nodes = $this->getCrawler()->filter('title');
+        if (!$nodes->count()) {
+            $this->assertTrue(true);
+            return;
+        }
+        $this->assertStringNotContainsString($title, $nodes->first()->text(), "page title contains $title");
+    }
+
+    public function seeCookie($cookie, array $params = [])
+    {
+        $params = array_merge($this->defaultCookieParameters, $params);
+        $this->debugCookieJar();
+        $this->assertNotNull($this->client->getCookieJar()->get($cookie, $params['path'], $params['domain']));
+    }
+
+    public function dontSeeCookie($cookie, array $params = [])
+    {
+        $params = array_merge($this->defaultCookieParameters, $params);
+        $this->debugCookieJar();
+        $this->assertNull($this->client->getCookieJar()->get($cookie, $params['path'], $params['domain']));
+    }
+
+    public function setCookie($name, $val, array $params = [])
+    {
+        $cookies = $this->client->getCookieJar();
+        $params = array_merge($this->defaultCookieParameters, $params);
+
+        $expires      = isset($params['expiry']) ? $params['expiry'] : null; // WebDriver compatibility
+        $expires      = isset($params['expires']) && !$expires ? $params['expires'] : null;
+        $path         = isset($params['path'])    ? $params['path'] : null;
+        $domain       = isset($params['domain'])  ? $params['domain'] : '';
+        $secure       = isset($params['secure'])  ? $params['secure'] : false;
+        $httpOnly     = isset($params['httpOnly'])  ? $params['httpOnly'] : true;
+        $encodedValue = isset($params['encodedValue'])  ? $params['encodedValue'] : false;
+
+        $cookies->set(new Cookie($name, $val, $expires, $path, $domain, $secure, $httpOnly, $encodedValue));
+        $this->debugCookieJar();
+    }
+
+    public function resetCookie($name, array $params = [])
+    {
+        $params = array_merge($this->defaultCookieParameters, $params);
+        $this->client->getCookieJar()->expire($name, $params['path'], $params['domain']);
+        $this->debugCookieJar();
+    }
+
+    public function grabCookie($cookie, array $params = [])
+    {
+        $params = array_merge($this->defaultCookieParameters, $params);
+        $this->debugCookieJar();
+        $cookies = $this->getRunningClient()->getCookieJar()->get($cookie, $params['path'], $params['domain']);
+        if (!$cookies) {
+            return null;
+        }
+        return $cookies->getValue();
+    }
+
+    /**
+     * Grabs current page source code.
+     *
+     * @return string Current page source code.
+     */
+    public function grabPageSource()
+    {
+        return $this->_getResponseContent();
+    }
+}


### PR DESCRIPTION
General refactor to file `InnerBrowser.php`.

This PR...
- [x] makes it easier to navigate through the class.
- [x] reduces the file size from 2065 lines to 1626.
- [x] does not make logic changes.
- [x] creates individual traits responsible for the implementation of each interface used in the class.
- [x] respect the order of implementation of the methods.
- [x] organizes the methods: `private` first, `protected` second and `public` last.
- [x] alphabetize methods.
- [x] uses ʻuse` statements if possible.
- [x] adds `BrowserInterface` to see clearly (without docblocks or code implementation) which public methods this class provides.