### PR TITLE
Fix `TypeError` in PHP8

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -1430,7 +1430,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
 
     public function grabTextFrom($cssOrXPathOrRegex)
     {
-        if (@preg_match($cssOrXPathOrRegex, $this->client->getInternalResponse()->getContent(), $matches)) {
+        if (is_string($cssOrXPathOrRegex) && @preg_match($cssOrXPathOrRegex, $this->client->getInternalResponse()->getContent(), $matches)) {
             return $matches[1];
         }
         $nodes = $this->match($cssOrXPathOrRegex);


### PR DESCRIPTION
PHP8 throws a `TypeError` when we pass an array to `preg_match`, suppression with `@` doesn't work in this scenario. Since `preg_match()` would never return a truthy value if not passed a string this change shouldn't impact any other cases or PHP versions.