### PR TITLE
Fix uncheck checkbox and submit input type hidden value

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -1072,7 +1072,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             }
 
             if (!$field->hasValue()) {
-                // if unchecked a checkboc and if there is hidden input with same name to submit unchecked value
+                // if unchecked a checkbox and if there is hidden input with same name to submit unchecked value
                 $hiddenInput = $formNodeCrawler->filter('input[type=hidden][name="'.$field->getName().'"]:not([disabled])');
                 if (!count($hiddenInput)) {
                     continue;

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -1067,16 +1067,22 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $values = [];
         $fields = $form->all();
         foreach ($fields as $field) {
-            if ($field instanceof FileFormField || $field->isDisabled()
-                ||
-                !$field->hasValue()
-            ) {
+            if ($field instanceof FileFormField || $field->isDisabled()) {
+                continue;
+            }
+
+            if (!$field->hasValue()) {
                 // if unchecked a checkboc and if there is hidden input with same name to submit unchecked value
                 $hiddenInput = $formNodeCrawler->filter('input[type=hidden][name="'.$field->getName().'"]:not([disabled])');
                 if (!count($hiddenInput)) {
                     continue;
+                } else {
+                    // there might be multiple hidden input with same name, but we will only grab last one's value
+                    $hiddenFieldValue = $hiddenInput->last()->attr('value');
                 }
             }
+
+
             $fieldName = $this->getSubmissionFormFieldName($field->getName());
             if (substr($field->getName(), -2) === '[]') {
                 if (!isset($values[$fieldName])) {
@@ -1084,10 +1090,9 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
                 }
                 $values[$fieldName][] = $field->getValue();
             } else {
-                if (isset($hiddenInput) && count($hiddenInput)) {
-                    // there might be multiple hidden input with same name, but we will only grab last one's value
-                    $values[$fieldName] = $hiddenInput->last()->attr('value');
-                    unset($hiddenInput);
+                if (isset($hiddenFieldValue)) {
+                    $values[$fieldName] = $hiddenFieldValue;
+                    unset($hiddenFieldValue);
                 } else {
                     $values[$fieldName] = $field->getValue();
                 }

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -1072,7 +1072,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
                 !$field->hasValue()
             ) {
                 // if unchecked a checkboc and if there is hidden input with same name to submit unchecked value
-                $hiddenInput = $formNodeCrawler->filter('input[type=hidden][name="'.$field->getName().'"]');
+                $hiddenInput = $formNodeCrawler->filter('input[type=hidden][name="'.$field->getName().'"]:not([disabled])');
                 if (!count($hiddenInput)) {
                     continue;
                 }

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -1078,8 +1078,10 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
                     continue;
                 } else {
                     // there might be multiple hidden input with same name, but we will only grab last one's value
-                    $hiddenFieldValue = $hiddenInput->last()->attr('value');
+                    $fieldValue = $hiddenInput->last()->attr('value');
                 }
+            } else {
+                $fieldValue = $field->getValue();
             }
 
 
@@ -1088,14 +1090,9 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
                 if (!isset($values[$fieldName])) {
                     $values[$fieldName] = [];
                 }
-                $values[$fieldName][] = $field->getValue();
+                $values[$fieldName][] = $fieldValue;
             } else {
-                if (isset($hiddenFieldValue)) {
-                    $values[$fieldName] = $hiddenFieldValue;
-                    unset($hiddenFieldValue);
-                } else {
-                    $values[$fieldName] = $field->getValue();
-                }
+                $values[$fieldName] = $fieldValue;
             }
         }
         return $values;

--- a/tests/data/app/view/form/button.php
+++ b/tests/data/app/view/form/button.php
@@ -6,3 +6,4 @@
 </form>
 </body>
 </html>
+s

--- a/tests/data/app/view/form/button.php
+++ b/tests/data/app/view/form/button.php
@@ -6,5 +6,3 @@
 </form>
 </body>
 </html>
-s
-s

--- a/tests/data/app/view/form/button.php
+++ b/tests/data/app/view/form/button.php
@@ -7,3 +7,4 @@
 </body>
 </html>
 s
+s

--- a/tests/data/app/view/form/uncheck_hidden.php
+++ b/tests/data/app/view/form/uncheck_hidden.php
@@ -5,6 +5,8 @@
     <input type="hidden" name="coffee" value="123"> <!-- this should be discarded -->
 
     <!-- Do you need coffee ? (label) -->
+    <input type="hidden" name="coffee" value="8569" disabled="disabled">
+    <input type="hidden" name="coffee" value="8">
     <input type="hidden" name="coffee" value="0">
     <input type="checkbox" name="coffee" value="1" id="coffee-id" checked>
 

--- a/tests/data/app/view/form/uncheck_hidden.php
+++ b/tests/data/app/view/form/uncheck_hidden.php
@@ -1,8 +1,17 @@
 <form method="POST" action="/form/uncheck_hidden">
 
+    <input type="text" name="wireless" value="mouse">
+
+    <input type="hidden" name="coffee" value="123"> <!-- this should be discarded -->
+
     <!-- Do you need coffee ? (label) -->
     <input type="hidden" name="coffee" value="0">
     <input type="checkbox" name="coffee" value="1" id="coffee-id" checked>
+
+    <!-- check all other work as intended -->
+    <input type="checkbox" name="tea" value="1" id="tea-id" checked>
+    <input type="checkbox" name="vanilla" id="vanilla-id" checked>
+    <input type="checkbox" name="butter" id="butter-id" >
 
     <button type="submit">Submit Preference</button>
 </form>

--- a/tests/data/app/view/form/uncheck_hidden.php
+++ b/tests/data/app/view/form/uncheck_hidden.php
@@ -1,0 +1,8 @@
+<form method="POST" action="/form/uncheck_hidden">
+
+    <!-- Do you need coffee ? (label) -->
+    <input type="hidden" name="coffee" value="0">
+    <input type="checkbox" name="coffee" value="1" id="coffee-id" checked>
+
+    <button type="submit">Submit Preference</button>
+</form>

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -1788,5 +1788,12 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->click("Submit Preference");
         $form = data::get('form');
         $this->assertEquals('0', $form['coffee']);
+
+        // test all other inputs are submitted as intended
+        $this->assertEquals('mouse', $form['wireless']);
+        $this->assertEquals('1', $form['tea']);
+        $this->assertEquals('on', $form['vanilla']); // 'on' is set internally
+        $this->assertFalse(isset($form['butter']));
+
     }
 }

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -1780,4 +1780,13 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $server = $this->module->client->getRequest()->getServer();
         $this->assertArrayHasKey('my', $server);
     }
+
+    public function testUncheckHidden()
+    {
+        $this->module->amOnPage('/form/uncheck_hidden');
+        $this->module->uncheckOption('#coffee-id');
+        $this->module->click("Submit Preference");
+        $form = data::get('form');
+        $this->assertEquals('0', $form['coffee']);
+    }
 }


### PR DESCRIPTION
**Current status**

When a form have following inputs:

```html
<input type="hidden" name="coffee" value="0">
<input type="checkbox" name="coffee" value="1" id="coffee-id" checked>
```

and when checkbox is unchecked and then if the form is submitted, value `'0'` of `coffee` is not sent.

Ideally it should.

This PR fix that issue.

Failing test: https://github.com/Codeception/lib-innerbrowser/commit/d56484c53467ef5e2abb2b4d2bcd778f36679a8a

@SamMousa 

Have any questions, feel free to ask