### PR TITLE
Code standards updated to PHP 7.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4, 8.0]
+        php: [7.3, 7.4, 8.0]
 
     steps:
     - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0]
+        php: [7.1, 7.2, 7.3, 7.4, 8.0]
 
     steps:
     - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"ext-dom": "*",
 		"ext-json": "*",
 		"ext-mbstring": "*",
-		"codeception/codeception": "^5.0 || *@dev",
+		"codeception/codeception": "dev-5.0-interfaces",
 		"symfony/browser-kit": ">=4.4 <6.0",
 		"symfony/dom-crawler": ">=4.4 <6.0"
 	},

--- a/composer.json
+++ b/composer.json
@@ -1,44 +1,45 @@
 {
-    "name":"codeception/lib-innerbrowser",
-    "description":"Parent library for all Codeception framework modules and PhpBrowser",
-    "keywords":["codeception"],
-    "homepage":"https://codeception.com/",
-    "type":"library",
-    "license":"MIT",
-    "authors":[
-        {
-            "name":"Michael Bodnarchuk",
-            "email":"davert@mail.ua",
-            "homepage":"http://codegyre.com"
-        },
-        {
-            "name":"Gintautas Miselis"
-        }
-    ],
-    "minimum-stability": "RC",
-
-    "require": {
-        "php": ">=5.6.0 <9.0",
-        "codeception/codeception": "*@dev",
-        "symfony/browser-kit": ">=2.7 <6.0",
-        "symfony/dom-crawler": ">=2.7 <6.0",
-        "ext-mbstring": "*",
-        "ext-dom": "*",
-        "ext-json": "*"
-    },
-    "require-dev": {
-        "codeception/util-universalframework": "dev-master"
-    },
-    "conflict": {
-        "codeception/codeception": "<4.0"
-    },
-    "autoload":{
-        "classmap": ["src/"]
-    },
-    "config": {
-        "classmap-authoritative": true
-    },
-    "scripts": {
-        "test": "codecept run --coverage-xml"
-    }
+	"name": "codeception/lib-innerbrowser",
+	"description": "Parent library for all Codeception framework modules and PhpBrowser",
+	"keywords": [ "codeception" ],
+	"homepage": "https://codeception.com/",
+	"type": "library",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "Michael Bodnarchuk",
+			"email": "davert@mail.ua",
+			"homepage": "https://codegyre.com"
+		},
+		{
+			"name": "Gintautas Miselis"
+		}
+	],
+	"minimum-stability": "RC",
+	"require": {
+		"php": "^7.1 || ^8.0",
+		"ext-dom": "*",
+		"ext-json": "*",
+		"ext-mbstring": "*",
+		"codeception/codeception": "*@dev",
+		"symfony/browser-kit": ">=3.4 <6.0",
+		"symfony/dom-crawler": ">=3.4 <6.0"
+	},
+	"require-dev": {
+		"codeception/util-universalframework": "dev-master"
+	},
+	"conflict": {
+		"codeception/codeception": "<4.0"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"config": {
+		"classmap-authoritative": true
+	},
+	"scripts": {
+		"test": "codecept run --coverage-xml"
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -17,19 +17,19 @@
 	],
 	"minimum-stability": "RC",
 	"require": {
-		"php": "^7.1 || ^8.0",
+		"php": "^7.3 || ^8.0",
 		"ext-dom": "*",
 		"ext-json": "*",
 		"ext-mbstring": "*",
-		"codeception/codeception": "*@dev",
-		"symfony/browser-kit": ">=3.4 <6.0",
-		"symfony/dom-crawler": ">=3.4 <6.0"
+		"codeception/codeception": "^5.0 || *@dev",
+		"symfony/browser-kit": ">=4.4 <6.0",
+		"symfony/dom-crawler": ">=4.4 <6.0"
 	},
 	"require-dev": {
 		"codeception/util-universalframework": "dev-master"
 	},
 	"conflict": {
-		"codeception/codeception": "<4.0"
+		"codeception/codeception": "<5.0"
 	},
 	"autoload": {
 		"classmap": [

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Parent library for all Codeception framework modules and PhpBrowser.
 
 ## Requirements
 
-* `PHP 7.1` or higher.
+* `PHP 7.3` or higher.
 
 ## Installation
 

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,10 @@ Parent library for all Codeception framework modules and PhpBrowser.
 [![Total Downloads](https://poser.pugx.org/codeception/lib-innerbrowser/downloads)](https://packagist.org/packages/codeception/lib-innerbrowser)
 [![License](https://poser.pugx.org/codeception/lib-innerbrowser/license)](/LICENSE)
 
+## Requirements
+
+* `PHP 7.1` or higher.
+
 ## Installation
 
 ```

--- a/src/Codeception/Exception/ExternalUrlException.php
+++ b/src/Codeception/Exception/ExternalUrlException.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Exception;
 
-class ExternalUrlException extends \Exception
+use Exception;
+
+class ExternalUrlException extends Exception
 {
 }

--- a/src/Codeception/Lib/Framework.php
+++ b/src/Codeception/Lib/Framework.php
@@ -1,21 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Lib;
 
 /**
  * Abstract module for PHP frameworks connected via Symfony BrowserKit components
  * Each framework is connected with it's own connector defined in \Codeception\Lib\Connector
  * Each module for framework should extend this class.
- *
  */
 abstract class Framework extends InnerBrowser
 {
     /**
      * Returns a list of recognized domain names
-     *
-     * @return array
      */
-    protected function getInternalDomains()
+    protected function getInternalDomains(): array
     {
         return [];
     }

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Lib;
 
 use Codeception\Exception\ElementNotFound;
@@ -109,7 +111,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         }
 
         $responseContentType = $internalResponse ? $internalResponse->getHeader('content-type') : '';
-        list($responseMimeType) = explode(';', $responseContentType);
+        [$responseMimeType] = explode(';', $responseContentType);
 
         $extension = $extensions[$responseMimeType] ?? 'html';
 
@@ -127,12 +129,15 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $this->headers = [];
     }
 
-    public function _conflicts()
+    /**
+     * @return class-string
+     */
+    public function _conflicts(): string
     {
         return \Codeception\Lib\Interfaces\Web::class;
     }
 
-    public function _findElements($locator)
+    public function _findElements(array $locator)
     {
         return $this->match($locator);
     }
@@ -339,7 +344,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         return $this->client;
     }
 
-    public function _savePageSource($filename)
+    public function _savePageSource(string $filename): void
     {
         file_put_contents($filename, $this->_getResponseContent());
     }
@@ -409,12 +414,12 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         unset($this->headers[$name]);
     }
 
-    public function amOnPage($page)
+    public function amOnPage(string $page): void
     {
         $this->_loadPage('GET', $page);
     }
 
-    public function click($link, $context = null)
+    public function click($link, $context = null): void
     {
         if ($context) {
             $this->crawler = $this->match($context);
@@ -548,7 +553,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         return $this->getAbsoluteUrlFor($baseUrl);
     }
 
-    public function see($text, $selector = null)
+    public function see(string $text, $selector = null): void
     {
         if (!$selector) {
             $this->assertPageContains($text);
@@ -559,7 +564,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $this->assertDomContains($nodes, $this->stringifySelector($selector), $text);
     }
 
-    public function dontSee($text, $selector = null)
+    public function dontSee(string $text, $selector = null): void
     {
         if (!$selector) {
             $this->assertPageNotContains($text);
@@ -570,17 +575,17 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $this->assertDomNotContains($nodes, $this->stringifySelector($selector), $text);
     }
 
-    public function seeInSource($raw)
+    public function seeInSource(string $raw): void
     {
         $this->assertPageSourceContains($raw);
     }
 
-    public function dontSeeInSource($raw)
+    public function dontSeeInSource(string $raw): void
     {
         $this->assertPageSourceNotContains($raw);
     }
 
-    public function seeLink($text, $url = null)
+    public function seeLink(string $text, string $url = null): void
     {
         $crawler = $this->getCrawler()->selectLink($text);
         if ($crawler->count() === 0) {
@@ -595,16 +600,15 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $this->assertTrue(true);
     }
 
-    public function dontSeeLink($text, $url = null)
+    public function dontSeeLink(string $text, string $url = null): void
     {
-        $url = (string) $url;
         $crawler = $this->getCrawler()->selectLink($text);
         if (!$url && $crawler->count() > 0) {
             $this->fail("Link containing text '$text' was found in page " . $this->_getCurrentUri());
         }
         $crawler = $crawler->filterXPath(
             sprintf('.//a[substring(@href, string-length(@href) - string-length(%1$s) + 1)=%1$s]',
-                SymfonyCrawler::xpathLiteral($url))
+                SymfonyCrawler::xpathLiteral((string) $url))
         );
         if ($crawler->count() > 0) {
             $this->fail("Link containing text '$text' and URL '$url' was found in page " . $this->_getCurrentUri());
@@ -620,37 +624,37 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         return Uri::retrieveUri($this->getRunningClient()->getHistory()->current()->getUri());
     }
 
-    public function seeInCurrentUrl($uri)
+    public function seeInCurrentUrl(string $uri): void
     {
         $this->assertStringContainsString($uri, $this->_getCurrentUri());
     }
 
-    public function dontSeeInCurrentUrl($uri)
+    public function dontSeeInCurrentUrl(string $uri): void
     {
         $this->assertStringNotContainsString($uri, $this->_getCurrentUri());
     }
 
-    public function seeCurrentUrlEquals($uri)
+    public function seeCurrentUrlEquals(string $uri): void
     {
         $this->assertEquals(rtrim($uri, '/'), rtrim($this->_getCurrentUri(), '/'));
     }
 
-    public function dontSeeCurrentUrlEquals($uri)
+    public function dontSeeCurrentUrlEquals(string $uri): void
     {
         $this->assertNotEquals(rtrim($uri, '/'), rtrim($this->_getCurrentUri(), '/'));
     }
 
-    public function seeCurrentUrlMatches($uri)
+    public function seeCurrentUrlMatches(string $uri): void
     {
         $this->assertRegExp($uri, $this->_getCurrentUri());
     }
 
-    public function dontSeeCurrentUrlMatches($uri)
+    public function dontSeeCurrentUrlMatches(string $uri): void
     {
         $this->assertNotRegExp($uri, $this->_getCurrentUri());
     }
 
-    public function grabFromCurrentUrl($uri = null)
+    public function grabFromCurrentUrl(string $uri = null)
     {
         if (!$uri) {
             return $this->_getCurrentUri();
@@ -666,36 +670,36 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         return $matches[1];
     }
 
-    public function seeCheckboxIsChecked($checkbox)
+    public function seeCheckboxIsChecked($checkbox): void
     {
         $checkboxes = $this->getFieldsByLabelOrCss($checkbox);
         $this->assertDomContains($checkboxes->filter('input[checked=checked]'), 'checkbox');
     }
 
-    public function dontSeeCheckboxIsChecked($checkbox)
+    public function dontSeeCheckboxIsChecked($checkbox): void
     {
         $checkboxes = $this->getFieldsByLabelOrCss($checkbox);
         $this->assertEquals(0, $checkboxes->filter('input[checked=checked]')->count());
     }
 
-    public function seeInField($field, $value)
+    public function seeInField($field, $value): void
     {
         $nodes = $this->getFieldsByLabelOrCss($field);
         $this->assert($this->proceedSeeInField($nodes, $value));
     }
 
-    public function dontSeeInField($field, $value)
+    public function dontSeeInField($field, $value): void
     {
         $nodes = $this->getFieldsByLabelOrCss($field);
         $this->assertNot($this->proceedSeeInField($nodes, $value));
     }
 
-    public function seeInFormFields($formSelector, array $params)
+    public function seeInFormFields($formSelector, array $params): void
     {
         $this->proceedSeeInFormFields($formSelector, $params, false);
     }
 
-    public function dontSeeInFormFields($formSelector, array $params)
+    public function dontSeeInFormFields($formSelector, array $params): void
     {
         $this->proceedSeeInFormFields($formSelector, $params, true);
     }
@@ -712,7 +716,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             $this->pushFormField($fields, $form, $name, $values);
         }
 
-        foreach ($fields as list($field, $values)) {
+        foreach ($fields as [$field, $values]) {
             if (!is_array($values)) {
                 $values = [$values];
             }
@@ -954,7 +958,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $this->forms = [];
     }
 
-    public function submitForm($selector, array $params, $button = null)
+    public function submitForm($selector, array $params, $button = null): void
     {
         $form = $this->match($selector)->first();
         if (count($form) === 0) {
@@ -1112,8 +1116,9 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         return $values;
     }
 
-    public function fillField($field, $value)
+    public function fillField($field, $value): void
     {
+        $value = (string) $value;
         $input = $this->getFieldByLabelOrCss($field);
         $form = $this->getFormFor($input);
         $name = $input->attr('name');
@@ -1174,7 +1179,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         return $input->first();
     }
 
-    public function selectOption($select, $option)
+    public function selectOption($select, $option): void
     {
         $field = $this->getFieldByLabelOrCss($select);
         $form = $this->getFormFor($field);
@@ -1244,12 +1249,12 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         return $option;
     }
 
-    public function checkOption($option)
+    public function checkOption($option): void
     {
         $this->proceedCheckOption($option)->tick();
     }
 
-    public function uncheckOption($option)
+    public function uncheckOption($option): void
     {
         $this->proceedCheckOption($option)->untick();
     }
@@ -1275,7 +1280,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         return $formField;
     }
 
-    public function attachFile($field, $filename)
+    public function attachFile($field, string $filename): void
     {
         $form = $this->getFormFor($field = $this->getFieldByLabelOrCss($field));
         $filePath = codecept_data_dir() . $filename;
@@ -1364,7 +1369,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $this->debugSection('Response Headers', $this->getRunningClient()->getInternalResponse()->getHeaders());
     }
 
-    public function makeHtmlSnapshot($name = null)
+    public function makeHtmlSnapshot(string $name = null): void
     {
         if (empty($name)) {
             $name = uniqid(date("Y-m-d_H-i-s_"), true);
@@ -1468,7 +1473,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         throw new ElementNotFound($cssOrXPathOrRegex, 'Element that matches CSS or XPath or Regex');
     }
 
-    public function grabAttributeFrom($cssOrXpath, $attribute)
+    public function grabAttributeFrom($cssOrXpath, string $attribute)
     {
         $nodes = $this->match($cssOrXpath);
         if ($nodes->count() === 0) {
@@ -1477,7 +1482,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         return $nodes->first()->attr($attribute);
     }
 
-    public function grabMultiple($cssOrXpath, $attribute = null)
+    public function grabMultiple($cssOrXpath, string $attribute = null): array
     {
         $result = [];
         $nodes = $this->match($cssOrXpath);
@@ -1528,7 +1533,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $this->fail("Element {$nodes} is not a form field or does not contain a form field");
     }
 
-    public function setCookie($name, $val, array $params = [])
+    public function setCookie(string $name, ?string $val, array $params = [])
     {
         $cookies = $this->client->getCookieJar();
         $params = array_merge($this->defaultCookieParameters, $params);
@@ -1548,7 +1553,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $this->debugCookieJar();
     }
 
-    public function grabCookie($cookie, array $params = [])
+    public function grabCookie(string $cookie, array $params = [])
     {
         $params = array_merge($this->defaultCookieParameters, $params);
         $this->debugCookieJar();
@@ -1565,26 +1570,26 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
      * @throws ModuleException if no page was opened.
      * @return string Current page source code.
      */
-    public function grabPageSource()
+    public function grabPageSource(): string
     {
         return $this->_getResponseContent();
     }
 
-    public function seeCookie($cookie, array $params = [])
+    public function seeCookie(string $cookie, array $params = [])
     {
         $params = array_merge($this->defaultCookieParameters, $params);
         $this->debugCookieJar();
         $this->assertNotNull($this->client->getCookieJar()->get($cookie, $params['path'], $params['domain']));
     }
 
-    public function dontSeeCookie($cookie, array $params = [])
+    public function dontSeeCookie(string $cookie, array $params = [])
     {
         $params = array_merge($this->defaultCookieParameters, $params);
         $this->debugCookieJar();
         $this->assertNull($this->client->getCookieJar()->get($cookie, $params['path'], $params['domain']));
     }
 
-    public function resetCookie($cookie, array $params = [])
+    public function resetCookie(string $cookie, array $params = [])
     {
         $params = array_merge($this->defaultCookieParameters, $params);
         $this->client->getCookieJar()->expire($cookie, $params['path'], $params['domain']);
@@ -1594,38 +1599,38 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     private function stringifySelector($selector): string
     {
         if (is_array($selector)) {
-            return trim(json_encode($selector), '{}');
+            return trim(json_encode($selector, JSON_THROW_ON_ERROR), '{}');
         }
         return $selector;
     }
 
-    public function seeElement($selector, $attributes = [])
+    public function seeElement($selector, array $attributes = []): void
     {
         $nodes = $this->match($selector);
         $selector = $this->stringifySelector($selector);
         if (!empty($attributes)) {
             $nodes = $this->filterByAttributes($nodes, $attributes);
-            $selector .= "' with attribute(s) '" . trim(json_encode($attributes), '{}');
+            $selector .= "' with attribute(s) '" . trim(json_encode($attributes, JSON_THROW_ON_ERROR), '{}');
         }
         $this->assertDomContains($nodes, $selector);
     }
 
-    public function dontSeeElement($selector, $attributes = [])
+    public function dontSeeElement($selector, array $attributes = []): void
     {
         $nodes = $this->match($selector);
         $selector = $this->stringifySelector($selector);
         if (!empty($attributes)) {
             $nodes = $this->filterByAttributes($nodes, $attributes);
-            $selector .= "' with attribute(s) '" . trim(json_encode($attributes), '{}');
+            $selector .= "' with attribute(s) '" . trim(json_encode($attributes, JSON_THROW_ON_ERROR), '{}');
         }
         $this->assertDomNotContains($nodes, $selector);
     }
 
-    public function seeNumberOfElements($selector, $expected)
+    public function seeNumberOfElements($selector, $expected): void
     {
         $counted = count($this->match($selector));
         if (is_array($expected)) {
-            list($floor, $ceil) = $expected;
+            [$floor, $ceil] = $expected;
             $this->assertTrue(
                 $floor <= $counted && $ceil >= $counted,
                 'Number of elements counted differs from expected range'
@@ -1639,7 +1644,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         }
     }
 
-    public function seeOptionIsSelected($selector, $optionText)
+    public function seeOptionIsSelected($selector, string $optionText)
     {
         $selected = $this->matchSelectedOption($selector);
         $this->assertDomContains($selected, 'selected option');
@@ -1650,7 +1655,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $this->assertEquals($optionText, $value);
     }
 
-    public function dontSeeOptionIsSelected($selector, $optionText)
+    public function dontSeeOptionIsSelected($selector, string $optionText)
     {
         $selected = $this->matchSelectedOption($selector);
         if ($selected->count() === 0) {
@@ -1776,7 +1781,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $this->seeResponseCodeIsBetween(500, 599);
     }
 
-    public function seeInTitle($title)
+    public function seeInTitle(string $title)
     {
         $nodes = $this->getCrawler()->filter('title');
         if ($nodes->count() === 0) {
@@ -1785,7 +1790,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $this->assertStringContainsString($title, $nodes->first()->text(), "page title contains $title");
     }
 
-    public function dontSeeInTitle($title)
+    public function dontSeeInTitle(string $title)
     {
         $nodes = $this->getCrawler()->filter('title');
         if ($nodes->count() === 0) {

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -23,6 +23,7 @@ use Codeception\Util\ReflectionHelper;
 use Codeception\Util\Uri;
 use DOMDocument;
 use DOMNode;
+use Exception;
 use InvalidArgumentException;
 use LogicException;
 use Symfony\Component\BrowserKit\AbstractBrowser;
@@ -78,6 +79,9 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
      */
     private $baseUrl;
 
+    /**
+     * @param Exception $fail
+     */
     public function _failed(TestInterface $test, $fail)
     {
         try {
@@ -260,7 +264,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         return $this->redirectIfNecessary($result, $maxRedirects, 0);
     }
 
-    protected function isInternalDomain($domain): bool
+    protected function isInternalDomain(string $domain): bool
     {
         if ($this->internalDomains === null) {
             $this->internalDomains = $this->getInternalDomains();
@@ -591,8 +595,9 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $this->assertTrue(true);
     }
 
-    public function dontSeeLink($text, $url = '')
+    public function dontSeeLink($text, $url = null)
     {
+        $url = (string) $url;
         $crawler = $this->getCrawler()->selectLink($text);
         if (!$url && $crawler->count() > 0) {
             $this->fail("Link containing text '$text' was found in page " . $this->_getCurrentUri());
@@ -1294,10 +1299,10 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
      * Sends an ajax GET request with the passed parameters.
      * See `sendAjaxPostRequest()`
      *
-     * @param $uri
+     * @param string $uri
      * @param array $params
      */
-    public function sendAjaxGetRequest($uri, array $params = []): void
+    public function sendAjaxGetRequest(string $uri, array $params = []): void
     {
         $this->sendAjaxRequest('GET', $uri, $params);
     }
@@ -1339,11 +1344,11 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
      * $I->sendAjaxRequest('PUT', '/posts/7', ['title' => 'new title']);
      * ```
      *
-     * @param $method
-     * @param $uri
+     * @param string $method
+     * @param string $uri
      * @param array $params
      */
-    public function sendAjaxRequest($method, $uri, array $params = []): void
+    public function sendAjaxRequest(string $method, string $uri, array $params = []): void
     {
         $this->clientRequest($method, $uri, $params, [], ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'], null, false);
     }
@@ -1802,7 +1807,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $this->assertThat($nodes, $constraint, $message);
     }
 
-    protected function assertPageContains($needle, string $message = ''): void
+    protected function assertPageContains(string $needle, string $message = ''): void
     {
         $constraint = new PageConstraint($needle, $this->_getCurrentUri());
         $this->assertThat(
@@ -1812,10 +1817,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         );
     }
 
-    /**
-     * @param string $message
-     */
-    protected function assertPageNotContains($needle, string $message = ''): void
+    protected function assertPageNotContains(string $needle, string $message = ''): void
     {
         $constraint = new PageConstraint($needle, $this->_getCurrentUri());
         $this->assertThatItsNot(
@@ -1825,10 +1827,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         );
     }
 
-    /**
-     * @param string $message
-     */
-    protected function assertPageSourceContains($needle, string $message = ''): void
+    protected function assertPageSourceContains(string $needle, string $message = ''): void
     {
         $constraint = new PageConstraint($needle, $this->_getCurrentUri());
         $this->assertThat(
@@ -1838,10 +1837,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         );
     }
 
-    /**
-     * @param string $message
-     */
-    protected function assertPageSourceNotContains($needle, string $message = ''): void
+    protected function assertPageSourceNotContains(string $needle, string $message = ''): void
     {
         $constraint = new PageConstraint($needle, $this->_getCurrentUri());
         $this->assertThatItsNot(
@@ -1872,11 +1868,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         throw new TestRuntimeException("None of form fields by {$name}[] were not matched");
     }
 
-    /**
-     * @param $locator
-     * @return SymfonyCrawler
-     */
-    protected function filterByCSS($locator): SymfonyCrawler
+    protected function filterByCSS(string $locator): SymfonyCrawler
     {
         if (!Locator::isCSS($locator)) {
             throw new MalformedLocatorException($locator, 'css');
@@ -1884,11 +1876,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         return $this->getCrawler()->filter($locator);
     }
 
-    /**
-     * @param $locator
-     * @return SymfonyCrawler
-     */
-    protected function filterByXPath($locator): SymfonyCrawler
+    protected function filterByXPath(string $locator): SymfonyCrawler
     {
         if (!Locator::isXPath($locator)) {
             throw new MalformedLocatorException($locator, 'xpath');

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -636,12 +636,12 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
 
     public function seeCurrentUrlEquals(string $uri): void
     {
-        $this->assertEquals(rtrim($uri, '/'), rtrim($this->_getCurrentUri(), '/'));
+        $this->assertSame(rtrim($uri, '/'), rtrim($this->_getCurrentUri(), '/'));
     }
 
     public function dontSeeCurrentUrlEquals(string $uri): void
     {
-        $this->assertNotEquals(rtrim($uri, '/'), rtrim($this->_getCurrentUri(), '/'));
+        $this->assertNotSame(rtrim($uri, '/'), rtrim($this->_getCurrentUri(), '/'));
     }
 
     public function seeCurrentUrlMatches(string $uri): void
@@ -679,7 +679,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     public function dontSeeCheckboxIsChecked($checkbox): void
     {
         $checkboxes = $this->getFieldsByLabelOrCss($checkbox);
-        $this->assertEquals(0, $checkboxes->filter('input[checked=checked]')->count());
+        $this->assertSame(0, $checkboxes->filter('input[checked=checked]')->count());
     }
 
     public function seeInField($field, $value): void
@@ -1636,7 +1636,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
                 'Number of elements counted differs from expected range'
             );
         } else {
-            $this->assertEquals(
+            $this->assertSame(
                 $expected,
                 $counted,
                 'Number of elements counted differs from expected number'
@@ -1652,21 +1652,21 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $value = $selected->getNode(0)->tagName === 'option'
             ? $selected->text()
             : $selected->getNode(0)->getAttribute('value');
-        $this->assertEquals($optionText, $value);
+        $this->assertSame($optionText, $value);
     }
 
     public function dontSeeOptionIsSelected($selector, string $optionText)
     {
         $selected = $this->matchSelectedOption($selector);
         if ($selected->count() === 0) {
-            $this->assertEquals(0, $selected->count());
+            $this->assertSame(0, $selected->count());
             return;
         }
         //If element is radio then we need to check value
         $value = $selected->getNode(0)->tagName === 'option'
             ? $selected->text()
             : $selected->getNode(0)->getAttribute('value');
-        $this->assertNotEquals($optionText, $value);
+        $this->assertNotSame($optionText, $value);
     }
 
     protected function matchSelectedOption($select): SymfonyCrawler
@@ -1707,7 +1707,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             HttpCode::getDescription($code),
             HttpCode::getDescription($this->getResponseStatusCode())
         );
-        $this->assertEquals($code, $this->getResponseStatusCode(), $failureMessage);
+        $this->assertSame($code, $this->getResponseStatusCode(), $failureMessage);
     }
 
     /**
@@ -1746,7 +1746,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             'Expected HTTP status code other than %s',
             HttpCode::getDescription($code)
         );
-        $this->assertNotEquals($code, $this->getResponseStatusCode(), $failureMessage);
+        $this->assertNotSame($code, $this->getResponseStatusCode(), $failureMessage);
     }
 
     /**

--- a/src/Codeception/Util/HttpCode.php
+++ b/src/Codeception/Util/HttpCode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
 /**
@@ -16,8 +18,6 @@ namespace Codeception\Util;
  * $I->seeResponseCodeIs(HttpCode::OK);
  * $I->dontSeeResponseCodeIs(HttpCode::NOT_FOUND);
  * ```
- *
- *
  */
 class HttpCode
 {
@@ -347,10 +347,9 @@ class HttpCode
      * HttpCode::getDescription(401); // '401 (Unauthorized)'
      * ```
      *
-     * @param int $code
      * @return int|string
      */
-    public static function getDescription($code)
+    public static function getDescription(int $code)
     {
         if (isset(self::$codes[$code])) {
             return sprintf('%d (%s)', $code, self::$codes[$code]);

--- a/tests/unit/Codeception/Constraints/CrawlerConstraintTest.php
+++ b/tests/unit/Codeception/Constraints/CrawlerConstraintTest.php
@@ -1,5 +1,8 @@
 <?php
-class CrawlerConstraintTest extends \Codeception\PHPUnit\TestCase
+
+declare(strict_types=1);
+
+final class CrawlerConstraintTest extends \Codeception\PHPUnit\TestCase
 {
 
     /**

--- a/tests/unit/Codeception/Constraints/CrawlerNotConstraintTest.php
+++ b/tests/unit/Codeception/Constraints/CrawlerNotConstraintTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class CrawlerNotConstraintTest extends \Codeception\PHPUnit\TestCase
+declare(strict_types=1);
+
+final class CrawlerNotConstraintTest extends \Codeception\PHPUnit\TestCase
 {
 
     /**

--- a/tests/unit/Codeception/Module/FrameworksTest.php
+++ b/tests/unit/Codeception/Module/FrameworksTest.php
@@ -93,7 +93,7 @@ final class FrameworksTest extends TestsForWeb
         $container = Stub::make('Codeception\Lib\ModuleContainer');
         $module = Stub::construct(get_class($this->module), [$container], [
             '_savePageSource' => Stub\Expected::once(function ($filename) {
-                $this->assertEquals(codecept_log_dir('Codeception.Module.UniversalFramework.looks.like..test.fail.html'), $filename);
+                $this->assertSame(codecept_log_dir('Codeception.Module.UniversalFramework.looks.like..test.fail.html'), $filename);
             }),
         ]);
         $module->_initialize();

--- a/tests/unit/Codeception/Module/FrameworksTest.php
+++ b/tests/unit/Codeception/Module/FrameworksTest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 use Codeception\Stub;
 
 require_once __DIR__ . '/TestsForWeb.php';
@@ -6,7 +9,7 @@ require_once __DIR__ . '/TestsForWeb.php';
 /**
  * @group appveyor
  */
-class FrameworksTest extends TestsForWeb
+final class FrameworksTest extends TestsForWeb
 {
     /**
      * @var \Codeception\Lib\Framework
@@ -79,6 +82,8 @@ class FrameworksTest extends TestsForWeb
                 $this->fail('Expected to get exception here');
             } catch (\InvalidArgumentException $e) {
                 codecept_debug('Exception: ' . $e->getMessage());
+            } catch (\TypeError $e) {
+                codecept_debug('Error: ' . $e->getMessage());
             }
         }
     }

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * Author: davert
  * Date: 13.01.12

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -205,7 +205,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->amOnPage('/form/button');
         $this->module->click("btn0");
         $form = data::get('form');
-        $this->assertEquals('val', $form['text']);
+        $this->assertSame('val', $form['text']);
     }
 
     public function testClickByLinkTitle()
@@ -232,7 +232,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->checkOption('#checkin');
         $this->module->click('Submit');
         $form = data::get('form');
-        $this->assertEquals('agree', $form['terms']);
+        $this->assertSame('agree', $form['terms']);
     }
 
     public function testCheckboxByName()
@@ -241,7 +241,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->checkOption('terms');
         $this->module->click('Submit');
         $form = data::get('form');
-        $this->assertEquals('agree', $form['terms']);
+        $this->assertSame('agree', $form['terms']);
     }
 
     public function testCheckboxByLabel()
@@ -250,7 +250,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->checkOption('I Agree');
         $this->module->click('Submit');
         $form = data::get('form');
-        $this->assertEquals('agree', $form['terms']);
+        $this->assertSame('agree', $form['terms']);
     }
 
     /**
@@ -263,7 +263,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->checkOption('#id2');
         $this->module->click('Submit');
         $form = data::get('form');
-        $this->assertEquals('second', reset($form['field']));
+        $this->assertSame('second', reset($form['field']));
     }
 
     public function testSelectByCss()
@@ -272,7 +272,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->selectOption('form select[name=age]', 'adult');
         $this->module->click('Submit');
         $form = data::get('form');
-        $this->assertEquals('adult', $form['age']);
+        $this->assertSame('adult', $form['age']);
     }
 
     public function testSelectByName()
@@ -281,7 +281,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->selectOption('age', 'adult');
         $this->module->click('Submit');
         $form = data::get('form');
-        $this->assertEquals('adult', $form['age']);
+        $this->assertSame('adult', $form['age']);
     }
 
     public function testSelectByLabel()
@@ -290,7 +290,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->selectOption('Select your age', 'dead');
         $this->module->click('Submit');
         $form = data::get('form');
-        $this->assertEquals('dead', $form['age']);
+        $this->assertSame('dead', $form['age']);
     }
 
     public function testSelectByLabelAndOptionText()
@@ -299,7 +299,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->selectOption('Select your age', '21-60');
         $this->module->click('Submit');
         $form = data::get('form');
-        $this->assertEquals('adult', $form['age']);
+        $this->assertSame('adult', $form['age']);
     }
 
     public function testSeeSelectedOption()
@@ -325,7 +325,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->seeOptionIsSelected('#age', 'below 13');
         $this->module->click('Submit');
         $form = data::get('form');
-        $this->assertEquals('child', $form['age'], 'first option was not submitted');
+        $this->assertSame('child', $form['age'], 'first option was not submitted');
     }
 
     /**
@@ -337,7 +337,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->amOnPage('/form/example8');
         $this->module->click('form button[value="second"]');
         $form = data::get('form');
-        $this->assertEquals('second', $form['submit']);
+        $this->assertSame('second', $form['submit']);
     }
 
     /**
@@ -351,7 +351,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->amOnPage('/form/example11');
         $this->module->click('form button[value="fifth"]');
         $form = data::get('form');
-        $this->assertEquals('fifth', $form['submit']);
+        $this->assertSame('fifth', $form['submit']);
     }
 
     public function testSelectMultipleOptionsByText()
@@ -360,7 +360,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->selectOption('What do you like the most?', array('Play Video Games', 'Have Sex'));
         $this->module->click('Submit');
         $form = data::get('form');
-        $this->assertEquals(array('play', 'adult'), $form['like']);
+        $this->assertSame(array('play', 'adult'), $form['like']);
     }
 
     public function testSelectMultipleOptionsByValue()
@@ -369,7 +369,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->selectOption('What do you like the most?', array('eat', 'adult'));
         $this->module->click('Submit');
         $form = data::get('form');
-        $this->assertEquals(array('eat', 'adult'), $form['like']);
+        $this->assertSame(array('eat', 'adult'), $form['like']);
     }
 
     public function testHidden()
@@ -377,7 +377,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->amOnPage('/form/hidden');
         $this->module->click('Submit');
         $form = data::get('form');
-        $this->assertEquals('kill_people', $form['action']);
+        $this->assertSame('kill_people', $form['action']);
     }
 
     public function testTextareaByCss()
@@ -386,7 +386,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->fillField('textarea', 'Nothing special');
         $this->module->click('Submit');
         $form = data::get('form');
-        $this->assertEquals('Nothing special', $form['description']);
+        $this->assertSame('Nothing special', $form['description']);
     }
 
     public function testTextareaByLabel()
@@ -395,7 +395,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->fillField('Description', 'Nothing special');
         $this->module->click('Submit');
         $form = data::get('form');
-        $this->assertEquals('Nothing special', $form['description']);
+        $this->assertSame('Nothing special', $form['description']);
     }
 
     public function testTextFieldByCss()
@@ -404,7 +404,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->fillField('#name', 'Nothing special');
         $this->module->click('Submit');
         $form = data::get('form');
-        $this->assertEquals('Nothing special', $form['name']);
+        $this->assertSame('Nothing special', $form['name']);
     }
 
     public function testTextFieldByName()
@@ -414,8 +414,8 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->fillField('LoginForm[password]', '123456');
         $this->module->click('Login');
         $login = data::get('form');
-        $this->assertEquals('davert', $login['LoginForm']['username']);
-        $this->assertEquals('123456', $login['LoginForm']['password']);
+        $this->assertSame('davert', $login['LoginForm']['username']);
+        $this->assertSame('123456', $login['LoginForm']['password']);
     }
 
     public function testTextFieldByLabel()
@@ -424,7 +424,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->fillField('Name', 'Nothing special');
         $this->module->click('Submit');
         $form = data::get('form');
-        $this->assertEquals('Nothing special', $form['name']);
+        $this->assertSame('Nothing special', $form['name']);
     }
 
     public function testTextFieldByLabelWithoutFor()
@@ -433,7 +433,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->fillField('Other label', 'Nothing special');
         $this->module->click('Submit');
         $form = data::get('form');
-        $this->assertEquals('Nothing special', $form['othername']);
+        $this->assertSame('Nothing special', $form['othername']);
     }
 
     public function testFileFieldByCss()
@@ -701,26 +701,26 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
     {
         $this->module->amOnPage('/');
         $result = $this->module->grabTextFrom('h1');
-        $this->assertEquals("Welcome to test app!", $result);
+        $this->assertSame("Welcome to test app!", $result);
         $result = $this->module->grabTextFrom('descendant-or-self::h1');
-        $this->assertEquals("Welcome to test app!", $result);
+        $this->assertSame("Welcome to test app!", $result);
         $result = $this->module->grabTextFrom('~Welcome to (\w+) app!~');
-        $this->assertEquals('test', $result);
+        $this->assertSame('test', $result);
     }
 
     public function testGrabValueFrom()
     {
         $this->module->amOnPage('/form/hidden');
         $result = $this->module->grabValueFrom('#action');
-        $this->assertEquals("kill_people", $result);
+        $this->assertSame("kill_people", $result);
         $result = $this->module->grabValueFrom("descendant-or-self::form/descendant::input[@name='action']");
-        $this->assertEquals("kill_people", $result);
+        $this->assertSame("kill_people", $result);
         $this->module->amOnPage('/form/textarea');
         $result = $this->module->grabValueFrom('#description');
-        $this->assertEquals('sunrise', $result);
+        $this->assertSame('sunrise', $result);
         $this->module->amOnPage('/form/select');
         $result = $this->module->grabValueFrom('#age');
-        $this->assertEquals('oldfag', $result);
+        $this->assertSame('oldfag', $result);
     }
 
     /**
@@ -731,19 +731,19 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->amOnPage('/form/bug3866');
         $this->module->fillField('empty', 'new value');
         $result = $this->module->grabValueFrom('#empty');
-        $this->assertEquals('new value', $result);
+        $this->assertSame('new value', $result);
         $this->module->fillField('empty_textarea', 'new value');
         $result = $this->module->grabValueFrom('#empty_textarea');
-        $this->assertEquals('new value', $result);
+        $this->assertSame('new value', $result);
         $this->module->fillField('//textarea[@name="textarea[name][]"]', 'new value');
         $result = $this->module->grabValueFrom('#textarea_with_square_bracket');
-        $this->assertEquals('new value', $result);
+        $this->assertSame('new value', $result);
     }
 
     public function testGrabAttributeFrom()
     {
         $this->module->amOnPage('/search');
-        $this->assertEquals('get', $this->module->grabAttributeFrom('form', 'method'));
+        $this->assertSame('get', $this->module->grabAttributeFrom('form', 'method'));
     }
 
     public function testLinksWithSimilarNames()
@@ -800,7 +800,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->dontSeeCookie('evil_cookie');
 
         $cookie = $this->module->grabCookie($cookie_name);
-        $this->assertEquals($cookie_value, $cookie);
+        $this->assertSame($cookie_value, $cookie);
 
         $this->module->resetCookie($cookie_name);
         $this->module->dontSeeCookie($cookie_name);
@@ -817,7 +817,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->dontSeeCookie('evil_cookie');
 
         $cookie = $this->module->grabCookie($cookie_name, ['path' => '/info']);
-        $this->assertEquals($cookie_value, $cookie);
+        $this->assertSame($cookie_value, $cookie);
 
         $this->module->resetCookie($cookie_name, ['path' => '/info']);
         $this->module->dontSeeCookie($cookie_name, ['path' => '/info']);
@@ -947,8 +947,8 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->checkOption('#LoginForm_rememberMe');
         $this->module->click('Login');
         $login = data::get('form');
-        $this->assertEquals('davert', $login['LoginForm']['username']);
-        $this->assertEquals('123456', $login['LoginForm']['password']);
+        $this->assertSame('davert', $login['LoginForm']['username']);
+        $this->assertSame('123456', $login['LoginForm']['password']);
         $this->assertNotEmpty($login['LoginForm']['rememberMe']);
     }
 
@@ -959,9 +959,9 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->fillField('input[name=password]', '123456');
         $this->module->click('Log on');
         $login = data::get('form');
-        $this->assertEquals('davert', $login['username']);
-        $this->assertEquals('123456', $login['password']);
-        $this->assertEquals('login', $login['action']);
+        $this->assertSame('davert', $login['username']);
+        $this->assertSame('123456', $login['password']);
+        $this->assertSame('login', $login['action']);
     }
 
     public function testAmpersand()
@@ -1044,13 +1044,13 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
                 'description' => 'Is Codeception maintainer'
         ));
         $form = data::get('form');
-        $this->assertEquals('Davert', $form['name']);
-        $this->assertEquals('Is Codeception maintainer', $form['description']);
+        $this->assertSame('Davert', $form['name']);
+        $this->assertSame('Is Codeception maintainer', $form['description']);
         $this->assertArrayNotHasKey('disabled_fieldset', $form);
         $this->assertArrayNotHasKey('disabled_fieldset_textarea', $form);
         $this->assertArrayNotHasKey('disabled_fieldset_select', $form);
         $this->assertArrayNotHasKey('disabled_field', $form);
-        $this->assertEquals('kill_all', $form['action']);
+        $this->assertSame('kill_all', $form['action']);
     }
 
     public function testSubmitFormWithFillField()
@@ -1062,8 +1062,8 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
             'description' => 'Is from Iliyum, NY'
         ]);
         $form = data::get('form');
-        $this->assertEquals('Kilgore Trout', $form['name']);
-        $this->assertEquals('Is from Iliyum, NY', $form['description']);
+        $this->assertSame('Kilgore Trout', $form['name']);
+        $this->assertSame('Is from Iliyum, NY', $form['description']);
     }
 
     public function testSubmitFormWithoutButton()
@@ -1073,7 +1073,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
                 'text' => 'Hello!'
         ));
         $form = data::get('form');
-        $this->assertEquals('Hello!', $form['text']);
+        $this->assertSame('Hello!', $form['text']);
     }
 
     public function testSubmitFormWithAmpersand()
@@ -1081,7 +1081,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->amOnPage('/form/submitform_ampersands');
         $this->module->submitForm('form', []);
         $form = data::get('form');
-        $this->assertEquals('this & that', $form['test']);
+        $this->assertSame('this & that', $form['test']);
     }
 
     public function testSubmitFormWithArrayField()
@@ -1104,8 +1104,8 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         ]);
         $form = data::get('form');
         $this->assertCount(2, $form['select']);
-        $this->assertEquals('see test one', $form['select'][0]);
-        $this->assertEquals('not seen four', $form['select'][1]);
+        $this->assertSame('see test one', $form['select'][0]);
+        $this->assertSame('not seen four', $form['select'][1]);
     }
 
     public function testSubmitFormWithMultiSelect()
@@ -1114,8 +1114,8 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->submitForm('form', []);
         $form = data::get('form');
         $this->assertCount(2, $form['select']);
-        $this->assertEquals('see test one', $form['select'][0]);
-        $this->assertEquals('see test two', $form['select'][1]);
+        $this->assertSame('see test one', $form['select'][0]);
+        $this->assertSame('see test two', $form['select'][1]);
     }
 
     public function testSubmitFormCheckboxWithArrayParameter()
@@ -1130,9 +1130,9 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         ]);
         $form = data::get('form');
         $this->assertCount(3, $form['checkbox']);
-        $this->assertEquals('not seen one', $form['checkbox'][0]);
-        $this->assertEquals('see test two', $form['checkbox'][1]);
-        $this->assertEquals('not seen three', $form['checkbox'][2]);
+        $this->assertSame('not seen one', $form['checkbox'][0]);
+        $this->assertSame('see test two', $form['checkbox'][1]);
+        $this->assertSame('not seen three', $form['checkbox'][2]);
     }
 
     public function testSubmitFormCheckboxWithBooleanArrayParameter()
@@ -1147,8 +1147,8 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         ]);
         $form = data::get('form');
         $this->assertCount(2, $form['checkbox']);
-        $this->assertEquals('not seen one', $form['checkbox'][0]);
-        $this->assertEquals('not seen two', $form['checkbox'][1]);
+        $this->assertSame('not seen one', $form['checkbox'][0]);
+        $this->assertSame('not seen two', $form['checkbox'][1]);
     }
 
     /**
@@ -1165,7 +1165,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->amOnPage('/form/textarea');
         $this->module->submitForm('form', []);
         $form = data::get('form');
-        $this->assertEquals('sunrise', $form['description']);
+        $this->assertSame('sunrise', $form['description']);
     }
 
     /**
@@ -1184,10 +1184,10 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
     public function testSelectTwoSubmitsByText()
     {
         $this->module->amOnPage('/form/select_two_submits');
-        $this->module->selectOption('What kind of sandwich would you like?', 2);
+        $this->module->selectOption('What kind of sandwich would you like?', '2');
         $this->module->click('Save');
         $form = data::get('form');
-        $this->assertEquals(2, $form['sandwich_select']);
+        $this->assertSame('2', $form['sandwich_select']);
     }
 
     public function testSelectTwoSubmitsByCSS()
@@ -1196,7 +1196,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->selectOption("form select[name='sandwich_select']", '2');
         $this->module->click('Save');
         $form = data::get('form');
-        $this->assertEquals(2, $form['sandwich_select']);
+        $this->assertSame('2', $form['sandwich_select']);
     }
 
     protected function shouldFail()
@@ -1215,8 +1215,8 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $form = data::get('form');
         $this->assertArrayHasKey('button2', $form);
         $this->assertArrayHasKey('username', $form);
-        $this->assertEquals('value2', $form['button2']);
-        $this->assertEquals('fred', $form['username']);
+        $this->assertSame('value2', $form['button2']);
+        $this->assertSame('fred', $form['username']);
     }
 
     /**
@@ -1230,8 +1230,8 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $form = data::get('form');
         $this->assertArrayHasKey('button2', $form);
         $this->assertArrayHasKey('username', $form);
-        $this->assertEquals('value2', $form['button2']);
-        $this->assertEquals('bob', $form['username']);
+        $this->assertSame('value2', $form['button2']);
+        $this->assertSame('bob', $form['username']);
     }
 
     /*
@@ -1274,8 +1274,8 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $form = data::get('form');
         $this->assertArrayHasKey('checkbox1', $form, 'Checkbox value not sent');
         $this->assertArrayHasKey('radio1', $form, 'Radio button value not sent');
-        $this->assertEquals('testing', $form['checkbox1']);
-        $this->assertEquals('to be sent', $form['radio1']);
+        $this->assertSame('testing', $form['checkbox1']);
+        $this->assertSame('to be sent', $form['radio1']);
     }
 
     public function testSubmitFormCheckboxWithBoolean()
@@ -1286,7 +1286,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         ));
         $form = data::get('form');
         $this->assertArrayHasKey('checkbox1', $form, 'Checkbox value not sent');
-        $this->assertEquals('testing', $form['checkbox1']);
+        $this->assertSame('testing', $form['checkbox1']);
 
         $this->module->amOnPage('/form/example16');
         $this->module->submitForm('form', array(
@@ -1325,7 +1325,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
             'Button values for buttons 1, 2 and 4 should not be set'
         );
         $this->assertArrayHasKey('button3', $form, 'Button value for button3 should be set');
-        $this->assertEquals($form['button3'], 'third', 'Button value for button3 should equal third');
+        $this->assertSame($form['button3'], 'third', 'Button value for button3 should equal third');
 
         $this->module->amOnPage('/form/form_with_buttons');
         $this->module->submitForm('form', array(
@@ -1337,7 +1337,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
             'Button values for buttons 1, 2 and 3 should not be set'
         );
         $this->assertArrayHasKey('button4', $form, 'Button value for button4 should be set');
-        $this->assertEquals($form['button4'], 'fourth', 'Button value for button4 should equal fourth');
+        $this->assertSame($form['button4'], 'fourth', 'Button value for button4 should equal fourth');
     }
 
     /**
@@ -1407,7 +1407,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->fillField('price', '19.99');
         $this->module->click('Create');
         $data = data::get('form');
-        $this->assertEquals('Special Widget', $data['title']);
+        $this->assertSame('Special Widget', $data['title']);
     }
 
     /**
@@ -1447,7 +1447,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $data = data::get('form');
         $this->assertArrayHasKey('second-field', $data);
         $this->assertArrayNotHasKey('first-field', $data);
-        $this->assertEquals('Killgore Trout', $data['second-field']);
+        $this->assertSame('Killgore Trout', $data['second-field']);
     }
 
     public function testSubmitAdjacentFormsByButton()
@@ -1459,7 +1459,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $data = data::get('form');
         $this->assertArrayHasKey('first-field', $data);
         $this->assertArrayNotHasKey('second-field', $data);
-        $this->assertEquals('First', $data['first-field']);
+        $this->assertSame('First', $data['first-field']);
 
         $this->module->amOnPage('/form/submit_adjacentforms');
         $this->module->fillField('first-field', 'First');
@@ -1468,7 +1468,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $data = data::get('form');
         $this->assertArrayNotHasKey('first-field', $data);
         $this->assertArrayHasKey('second-field', $data);
-        $this->assertEquals('Second', $data['second-field']);
+        $this->assertSame('Second', $data['second-field']);
     }
 
     public function testArrayField()
@@ -1521,7 +1521,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->fillField('Name', 'this & that');
         $this->module->click('Submit');
         $form = data::get('form');
-        $this->assertEquals('this & that', $form['name']);
+        $this->assertSame('this & that', $form['name']);
     }
 
     public function testSeeInDeactivatedField()
@@ -1545,20 +1545,20 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         
         $arr = $this->module->grabMultiple('#grab-multiple a:first-child');
         $this->assertCount(1, $arr);
-        $this->assertEquals('First', $arr[0]);
+        $this->assertSame('First', $arr[0]);
         
         $arr = $this->module->grabMultiple('#grab-multiple a');
         $this->assertCount(3, $arr);
-        $this->assertEquals('First', $arr[0]);
-        $this->assertEquals('Second', $arr[1]);
-        $this->assertEquals('Third', $arr[2]);
+        $this->assertSame('First', $arr[0]);
+        $this->assertSame('Second', $arr[1]);
+        $this->assertSame('Third', $arr[2]);
         
         // href for WebDriver with selenium returns a full link, so testing with ID
         $arr = $this->module->grabMultiple('#grab-multiple a', 'id');
         $this->assertCount(3, $arr);
-        $this->assertEquals('first-link', $arr[0]);
-        $this->assertEquals('second-link', $arr[1]);
-        $this->assertEquals('third-link', $arr[2]);
+        $this->assertSame('first-link', $arr[0]);
+        $this->assertSame('second-link', $arr[1]);
+        $this->assertSame('third-link', $arr[2]);
     }
 
     /**
@@ -1595,7 +1595,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->selectOption('age', ['value' => '20']);
         $this->module->click('Submit');
         $data = data::get('form');
-        $this->assertEquals('20', $data['age']);
+        $this->assertSame('20', $data['age']);
     }
 
     public function testSelectOptionTextSelector()
@@ -1758,7 +1758,7 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->fillField('password', new \Codeception\Step\Argument\PasswordArgument('thisissecret'));
         $this->module->click('Submit');
         $data = data::get('form');
-        $this->assertEquals('thisissecret', $data['password']);
+        $this->assertSame('thisissecret', $data['password']);
     }
 
 
@@ -1790,12 +1790,12 @@ abstract class TestsForWeb extends \Codeception\Test\Unit
         $this->module->uncheckOption('#coffee-id');
         $this->module->click("Submit Preference");
         $form = data::get('form');
-        $this->assertEquals('0', $form['coffee']);
+        $this->assertSame('0', $form['coffee']);
 
         // test all other inputs are submitted as intended
-        $this->assertEquals('mouse', $form['wireless']);
-        $this->assertEquals('1', $form['tea']);
-        $this->assertEquals('on', $form['vanilla']); // 'on' is set internally
+        $this->assertSame('mouse', $form['wireless']);
+        $this->assertSame('1', $form['tea']);
+        $this->assertSame('on', $form['vanilla']); // 'on' is set internally
         $this->assertFalse(isset($form['butter']));
 
     }

--- a/tests/unit/Codeception/Util/HttpCodeTest.php
+++ b/tests/unit/Codeception/Util/HttpCodeTest.php
@@ -8,14 +8,14 @@ final class HttpCodeTest extends \Codeception\Test\Unit
 {
     public function testHttpCodeConstants()
     {
-        $this->assertEquals(200, HttpCode::OK);
-        $this->assertEquals(404, HttpCode::NOT_FOUND);
+        $this->assertSame(200, HttpCode::OK);
+        $this->assertSame(404, HttpCode::NOT_FOUND);
     }
 
     public function testHttpCodeWithDescription()
     {
-        $this->assertEquals('200 (OK)', HttpCode::getDescription(200));
-        $this->assertEquals('301 (Moved Permanently)', HttpCode::getDescription(301));
-        $this->assertEquals('401 (Unauthorized)', HttpCode::getDescription(401));
+        $this->assertSame('200 (OK)', HttpCode::getDescription(200));
+        $this->assertSame('301 (Moved Permanently)', HttpCode::getDescription(301));
+        $this->assertSame('401 (Unauthorized)', HttpCode::getDescription(401));
     }
 }

--- a/tests/unit/Codeception/Util/HttpCodeTest.php
+++ b/tests/unit/Codeception/Util/HttpCodeTest.php
@@ -1,7 +1,10 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
-class HttpCodeTest extends \Codeception\Test\Unit
+final class HttpCodeTest extends \Codeception\Test\Unit
 {
     public function testHttpCodeConstants()
     {


### PR DESCRIPTION
- The minimum version of PHP is now **7.3**, Symfony **+4.4**
- Added strict types
- Added return types
- Added some typehints
- Removed unnecessary qualifiers

**NEW**:
- AssertSame instead of AssertEquals
- Support for Codeception 5