### PR TITLE
Renaming `(un)checkOption` to `(un)checkCheckbox`

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -1249,12 +1249,28 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         return $option;
     }
 
+    /**
+     * @deprecated Use checkCheckbox() instead
+     */
     public function checkOption($option): void
+    {
+        $this->checkCheckbox($option);
+    }
+
+    /**
+     * @deprecated Use uncheckCheckbox() instead
+     */
+    public function uncheckOption($option): void
+    {
+        $this->uncheckCheckbox($option);
+    }
+    
+    public function checkCheckbox($option): void
     {
         $this->proceedCheckOption($option)->tick();
     }
 
-    public function uncheckOption($option): void
+    public function uncheckCheckbox($option): void
     {
         $this->proceedCheckOption($option)->untick();
     }


### PR DESCRIPTION
See https://github.com/Codeception/Codeception/pull/6156#issuecomment-813291606

"Option" is an ambiguous term - e.g. `selectOption` refers to `<select>` and radio: https://codeception.com/docs/modules/Symfony#selectOption

TODO: Rename it here too: https://codeception.com/docs/modules/Symfony#submitForm