### PR TITLE
[BUG] : prevent "Uncaught TypeError: explode(): Argument #2 ($string) must be of type string, null given"

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -97,7 +97,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             $internalResponse = false;
         }
 
-        $responseContentType = $internalResponse ? $internalResponse->getHeader('content-type') : '';
+        $responseContentType = $internalResponse ? $internalResponse->getHeader('content-type') ?? '': '';
         [$responseMimeType] = explode(';', $responseContentType);
 
         $extension = $extensions[$responseMimeType] ?? 'html';

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -97,7 +97,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             $internalResponse = false;
         }
 
-        $responseContentType = $internalResponse ? $internalResponse->getHeader('content-type') ?? '': '';
+        $responseContentType = $internalResponse ? (string) $internalResponse->getHeader('content-type') : '';
         [$responseMimeType] = explode(';', $responseContentType);
 
         $extension = $extensions[$responseMimeType] ?? 'html';


### PR DESCRIPTION
# Bug
When a request was made but Content-Type header was set,
and an other normal exception is thrown

normal exception is not displayed because:

# Trace
```
Fatal error: Uncaught TypeError: explode(): Argument #2 ($string) must be of type string, null given in /var/www/html/vendor/codeception/lib-innerbrowser/src/Codeception/Lib/InnerBrowser.php:101
Stack trace:
#0 /var/www/html/vendor/codeception/lib-innerbrowser/src/Codeception/Lib/InnerBrowser.php(101): explode(';', NULL)
#1 /var/www/html/vendor/codeception/codeception/src/Codeception/Subscriber/Module.php(77): Codeception\Lib\InnerBrowser->_failed(Object(Codeception\Test\Cest), Object(PHPUnit\Framework\ExceptionWrapper))
``` 