### PR TITLE
Do not randomly click the first matching element

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -407,7 +407,10 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             $anchor = $this->getCrawler()->selectLink($link);
         }
 
-        if (count($anchor) > 0) {
+        if (count($anchor) > 1) {
+            throw new TestRuntimeException(count($anchor) . " matching elements found with [$link], try to be more precise about what to click");
+        }
+        if (count($anchor) === 1) {
             $this->openHrefFromDomNode($anchor->getNode(0));
             return;
         }


### PR DESCRIPTION
Here is my case. A simple web page with a menu and a form:

    <nav>
         <a href="/dolphins">Save the dolphins</a>
    </nav>

    ...

    <form action="/profile/update">
        <input type="text" name="email">
        <input type="submit" value="Save">
    </form>

And here is my test case

        $I->amOnPage('/profile');
        $I->fillField('email', 'david@test.com');
        $I->click('Save');
        $I->seeAlertMessage('success', 'Email updated');

In this case, I have a test fail. And it's difficult to understand what was the issue.

So in this PR, I suggest stopping clicking the first matching element on the page, but providing to the developer a appropriate error message about the click that was not precise enough.

Wdyt?