### PR TITLE
Bumped lowest supported versions of symfony components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "codeception/codeception": "*@dev",
-        "symfony/browser-kit": "^4.4 || ^5.4 || ^6.0",
-        "symfony/dom-crawler": "^4.4 || ^5.4 || ^6.0"
+        "symfony/browser-kit": "^4.4.24 || ^5.4 || ^6.0",
+        "symfony/dom-crawler": "^4.4.30 || ^5.4 || ^6.0"
     },
     "require-dev": {
         "codeception/util-universalframework": "dev-master"


### PR DESCRIPTION
Type error was fixed in dom-crawler v4.4.30
https://github.com/symfony/dom-crawler/commit/4632ae3567746c7e915c33c67a2fb6ab746090c4