### PR TITLE
Align seeCheckboxIsChecked() and dontSeeCheckboxIsChecked() parameter types

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -658,7 +658,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         $this->assertDomContains($checkboxes->filter('input[checked=checked]'), 'checkbox');
     }
 
-    public function dontSeeCheckboxIsChecked(string $checkbox): void
+    public function dontSeeCheckboxIsChecked($checkbox): void
     {
         $checkboxes = $this->getFieldsByLabelOrCss($checkbox);
         $this->assertSame(0, $checkboxes->filter('input[checked=checked]')->count());

--- a/tests/unit/Codeception/Module/TestsForWeb.php
+++ b/tests/unit/Codeception/Module/TestsForWeb.php
@@ -484,6 +484,7 @@ abstract class TestsForWeb extends Unit
     {
         $this->module->amOnPage('/form/checkbox');
         $this->module->dontSeeCheckboxIsChecked('#checkin');
+        $this->module->dontSeeCheckboxIsChecked(['css' => '#checkin']);
         $this->module->dontSeeCheckboxIsChecked('I Agree');
     }
 
@@ -491,6 +492,7 @@ abstract class TestsForWeb extends Unit
     {
         $this->module->amOnPage('/info');
         $this->module->seeCheckboxIsChecked('input[type=checkbox]');
+        $this->module->seeCheckboxIsChecked(['css' => 'input[type=checkbox]']);
         $this->module->seeCheckboxIsChecked('Checked');
     }
 


### PR DESCRIPTION
I've noticed an inconsistency whilst trying to upgrade to 5.0.0-RC2.

Both the `seeCheckboxIsChecked()` and `dontSeeCheckboxIsChecked()` used to accept an array parameter (e.g. `['css' => '.foobar']`), but `dontSeeCheckboxIsChecked()` no longer does.

I looked and it seems like there's nothing stopping both methods accepting the array formatted parameter, so I've removed the type on `dontSeeCheckboxIsChecked()` and added some test coverage.

I wasn't sure if lib-web also needed updating, but I can do that if necessary.