### PR TITLE
fix: checkbox handling

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -655,13 +655,13 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     public function seeCheckboxIsChecked($checkbox): void
     {
         $checkboxes = $this->getFieldsByLabelOrCss($checkbox);
-        $this->assertDomContains($checkboxes->filter('input[checked=checked]'), 'checkbox');
+        $this->assertGreaterThan(0, $checkboxes->filter('input[checked]')->count());
     }
 
     public function dontSeeCheckboxIsChecked($checkbox): void
     {
         $checkboxes = $this->getFieldsByLabelOrCss($checkbox);
-        $this->assertSame(0, $checkboxes->filter('input[checked=checked]')->count());
+        $this->assertSame(0, $checkboxes->filter('input[checked]')->count());
     }
 
     public function seeInField($field, $value): void

--- a/tests/data/app/view/form/checkbox_checked.php
+++ b/tests/data/app/view/form/checkbox_checked.php
@@ -1,0 +1,6 @@
+<html>
+<body>
+    <input type="checkbox" id="checkedbox1" checked="random"/>
+    <input type="checkbox" id="checkedbox2" checked/>
+</body>
+</html>


### PR DESCRIPTION
Fixes #22 as a side effect.

This PR improves handling of checkboxes.

- Improve tests to actually confirm negative flows as well, ie check that the assertion `seeCheckboxIsChecked` will actually fail on unchecked checkboxes. Using a single data provider all cases are tested for both `seeCheckboxIsChecked` and `seeCheckboxIsNotChecked` assertions.
- Per the spec allow any value for the checked attribute, so `<input type=checkbox checked=test/>` is now properly interpreted as checked as well.
