### PR TITLE
Use FQN for public methods

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -1569,7 +1569,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
     /**
      * Grabs current page source code.
      *
-     * @throws ModuleException if no page was opened.
+     * @throws \Codeception\Exception\ModuleException if no page was opened.
      * @return string Current page source code.
      */
     public function grabPageSource(): string


### PR DESCRIPTION
I was integrating PHPStan into my project and encountered that the generated helper classes copy the phpdoc blocks without fixing the imported classes, which makes PHPStan unable to understand which types they are referencing.

This fix adds an FQN for all public methods. I tested this change on my project and it solved the problem. I think this change will be useful for the whole community :)