### PR TITLE
Fix numeric key in form

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -1906,7 +1906,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
                 }
 
                 parse_str($qs, $expandedValue);
-                $varName = substr($name, 0, strlen(key($expandedValue)));
+                $varName = substr($name, 0, strlen((string)key($expandedValue)));
                 $requestParams = array_replace_recursive($requestParams, [$varName => current($expandedValue)]);
             }
         }


### PR DESCRIPTION
When trying to submit form with integer key, error `[TypeError] strlen(): Argument #1 ($string) must be of type string, int given` is thrown

Steps to reproduce
```php
$I->fillField('input[name="1[min]"]', 15);
$I->click('Save');
```
PHP 8.2