### PR TITLE
Fix crawler not being updated when manually following redirect

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -2127,7 +2127,9 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
      */
     public function followRedirect(): void
     {
-        $this->client->followRedirect();
+        $this->crawler = $this->client->followRedirect();
+        $this->baseUrl = $this->retrieveBaseUrl();
+        $this->forms = [];
     }
 
     /**

--- a/tests/data/app/view/index.php
+++ b/tests/data/app/view/index.php
@@ -30,6 +30,7 @@
 </div>
 
 <a href="/info" title="Link Title">Link Text</a>
+<a href="/redirect">Test redirect</a>
 
 
 A wise man said: "debug!"


### PR DESCRIPTION
If you manually follow a redirect the crawler contains the response for the request *before*.

~~I've targeted this at the 3.x branch is that's what my project is using, it does apply cleanly to master if necessary but I'd appreciate a new 3.x release if that's not too much trouble.~~