### PR TITLE
Fix name of unsetHttpHeader method

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -380,7 +380,7 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
      *
      * @param string $name the name of the header to unset.
      */
-    public function unsetHeader(string $name): void
+    public function unsetHttpHeader(string $name): void
     {
         $name = implode('-', array_map('ucfirst', explode('-', strtolower(str_replace('_', '-', $name)))));
         unset($this->headers[$name]);


### PR DESCRIPTION
The method below was calling `unsetHttpHeader` and failing.

`unsetHeader` hasn't been released yet.

Fixes #72 
Fixes #73 