### PR TITLE
Support PHPUnit 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-mbstring": "*",
         "codeception/codeception": "^5.0.8",
         "codeception/lib-web": "^1.0.1",
-        "phpunit/phpunit": "^10.0 || ^11.0",
+        "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0",
         "symfony/browser-kit": "^4.4.24 || ^5.4 || ^6.0 || ^7.0",
         "symfony/dom-crawler": "^4.4.30 || ^5.4 || ^6.0 || ^7.0"
     },


### PR DESCRIPTION
`PHPUnit\Framework\ExpectationFailedException` seems to be the only class from PHPUnit which is used by this package.

Therefore, this package is not affected by any BC breaking change in PHPUnit 12.