### PR TITLE
Fix moveBack() history pointer + add symmetric moveForward()

### DIFF
--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -280,9 +280,10 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         array $parameters = [],
         array $files = [],
         array $server = [],
-        ?string $content = null
+        ?string $content = null,
+        bool $changeHistory = true
     ): void {
-        $this->crawler = $this->clientRequest($method, $uri, $parameters, $files, $server, $content);
+        $this->crawler = $this->clientRequest($method, $uri, $parameters, $files, $server, $content, $changeHistory);
         $this->baseUrl = $this->retrieveBaseUrl();
         $this->forms = [];
     }
@@ -2006,7 +2007,8 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
             $request->getParameters(),
             $request->getFiles(),
             $request->getServer(),
-            $request->getContent()
+            $request->getContent(),
+            false
         );
     }
 

--- a/src/Codeception/Lib/InnerBrowser.php
+++ b/src/Codeception/Lib/InnerBrowser.php
@@ -2012,6 +2012,43 @@ class InnerBrowser extends Module implements Web, PageSourceSaver, ElementLocato
         );
     }
 
+    /**
+     * Moves forward in history.
+     *
+     * @param int $numberOfSteps (default value 1)
+     */
+    public function moveForward(int $numberOfSteps = 1): void
+    {
+        $request = null;
+        if (!is_int($numberOfSteps) || $numberOfSteps < 1) {
+            throw new InvalidArgumentException('numberOfSteps must be positive integer');
+        }
+
+        try {
+            $history = $this->getRunningClient()->getHistory();
+            for ($i = $numberOfSteps; $i > 0; --$i) {
+                $request = $history->forward();
+            }
+        } catch (LogicException $exception) {
+            throw new InvalidArgumentException(
+                sprintf(
+                'numberOfSteps is set to %d, but there are only %d forward steps in the history',
+                $numberOfSteps,
+                $numberOfSteps - $i
+            ), $exception->getCode(), $exception);
+        }
+
+        $this->_loadPage(
+            $request->getMethod(),
+            $request->getUri(),
+            $request->getParameters(),
+            $request->getFiles(),
+            $request->getServer(),
+            $request->getContent(),
+            false
+        );
+    }
+
     protected function debugCookieJar(): void
     {
         $cookies = $this->client->getCookieJar()->all();

--- a/tests/unit/Codeception/Module/FrameworksTest.php
+++ b/tests/unit/Codeception/Module/FrameworksTest.php
@@ -100,6 +100,50 @@ final class FrameworksTest extends TestsForWeb
         }
     }
 
+    public function testMoveForwardOneStep()
+    {
+        $this->module->amOnPage('/iframe');
+        $this->module->amOnPage('/info');
+        $this->module->amOnPage('/');
+        $this->module->moveBack(2);
+        $this->module->seeCurrentUrlEquals('/iframe');
+        $this->module->moveForward();
+        $this->module->seeCurrentUrlEquals('/info');
+        $this->module->moveForward();
+        $this->module->seeCurrentUrlEquals('/');
+    }
+
+    public function testMoveForwardTwoSteps()
+    {
+        $this->module->amOnPage('/iframe');
+        $this->module->amOnPage('/info');
+        $this->module->amOnPage('/');
+        $this->module->moveBack(2);
+        $this->module->seeCurrentUrlEquals('/iframe');
+        $this->module->moveForward(2);
+        $this->module->seeCurrentUrlEquals('/');
+    }
+
+    public function testMoveForwardThrowsExceptionIfNumberOfStepsIsInvalid()
+    {
+        $this->module->amOnPage('/iframe');
+        $this->module->amOnPage('/');
+        $this->module->moveBack();
+        $this->module->seeCurrentUrlEquals('/iframe');
+
+        $invalidValues = [0, -5, 1.5, 'a', 3];
+        foreach ($invalidValues as $invalidValue) {
+            try {
+                $this->module->moveForward($invalidValue);
+                $this->fail('Expected to get exception here');
+            } catch (InvalidArgumentException $exception) {
+                codecept_debug('Exception: ' . $exception->getMessage());
+            } catch (TypeError $error) {
+                codecept_debug('Error: ' . $error->getMessage());
+            }
+        }
+    }
+
     public function testCreateSnapshotOnFail()
     {
         $container = Stub::make(ModuleContainer::class);

--- a/tests/unit/Codeception/Module/FrameworksTest.php
+++ b/tests/unit/Codeception/Module/FrameworksTest.php
@@ -68,6 +68,17 @@ final class FrameworksTest extends TestsForWeb
         $this->module->seeCurrentUrlEquals('/iframe');
     }
 
+    public function testMoveBackPreservesForwardHistory()
+    {
+        $this->module->amOnPage('/iframe');
+        $this->module->amOnPage('/info');
+        $this->module->amOnPage('/');
+        $this->module->moveBack();
+        $this->module->seeCurrentUrlEquals('/info');
+        $this->module->moveBack();
+        $this->module->seeCurrentUrlEquals('/iframe');
+    }
+
     public function testMoveBackThrowsExceptionIfNumberOfStepsIsInvalid()
     {
         $this->module->amOnPage('/iframe');


### PR DESCRIPTION
## 1. Fix `moveBack()` to move the history pointer instead of appending

`moveBack()` replays the previous request via `_loadPage()`, which called `clientRequest()` with the default `$changeHistory = true`. Replaying with `changeHistory = true` **appends** the request to the BrowserKit history and discards the forward entries, so `moveBack()` didn't behave like a real Back button:

- the history pointer ended back on the **last** page after going back, and
- a second `moveBack()` no longer walked further back.

Demonstration (fails on `master`):

```php
$I->amOnPage('/iframe');
$I->amOnPage('/info');
$I->amOnPage('/');
$I->moveBack();
$I->seeCurrentUrlEquals('/info'); // ok
$I->moveBack();
$I->seeCurrentUrlEquals('/iframe'); // FAILS on master -> lands on '/info'
```

Fix: thread a `$changeHistory` flag through `_loadPage()` and pass `false` from `moveBack()`. Matches Symfony's native `AbstractBrowser::back()` (`requestFromRequest($request, false)`).

## 2. Add symmetric `moveForward()`

Symfony's `AbstractBrowser` exposes both `back()` and `forward()` with identical semantics (`$this->history->forward()` + `requestFromRequest($request, false)`). InnerBrowser only had `moveBack()`. This adds the mirror `moveForward(int $numberOfSteps = 1)`. It is only meaningful because the fix above keeps the forward stack intact:

```php
$I->amOnPage('/a');
$I->amOnPage('/b');
$I->moveBack();
$I->seeCurrentUrlEquals('/a');
$I->moveForward();
$I->seeCurrentUrlEquals('/b');
```

## Backward compatibility

No BC break:

- **`moveForward()`** — brand-new public method, purely additive.
- **`_loadPage()`** — gains a trailing optional parameter `bool $changeHistory = true`. Existing callers (incl. external Helpers using the `@api` method) are unaffected because the default preserves the previous behavior.
- **`moveBack()`** — signature unchanged; the change is a behavioral **bugfix** (back no longer mutates history). No relied-upon contract is removed.

## Why it matters downstream

`moveForward()` and a correct `moveBack()` make the framework history assertions reachable through public steps — e.g. `assertBrowserHistoryIsNotOnLastPage()` (Symfony `BrowserKitAssertionsTrait`, `symfony/browser-kit >= 7.4`), which previously had no step to position history off the last page. Unblocks the matching functional tests in `Codeception/symfony-module-tests` (#58, #59) for `codeception/module-symfony#240`.

## Tests

`moveBack`: added `testMoveBackPreservesForwardHistory` (fails on `master`, passes here).
`moveForward`: added `testMoveForwardOneStep`, `testMoveForwardTwoSteps`, `testMoveForwardThrowsExceptionIfNumberOfStepsIsInvalid`.
Full unit suite green: **209 tests, 469 assertions**.